### PR TITLE
Feature/standardize enum names

### DIFF
--- a/CommonTestUtilities/Repositories/CookingTimeReadOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/CookingTimeReadOnlyRepositoryBuilder.cs
@@ -12,24 +12,24 @@ namespace CommonTestUtilities.Repositories
 
         public ICookingTimeReadOnlyRepository Build() => _repository.Object;
 
-        public void ExistsCookingTime(CookingTimeEnum cookingTime)
+        public void ExistsCookingTime(CookingTime cookingTime)
         {
             _repository.Setup(repository => repository.ExistsCookingTime(cookingTime)).ReturnsAsync(true);
         }
 
-        public void DoesNotExistCookingTime(CookingTimeEnum cookingTime)
+        public void DoesNotExistCookingTime(CookingTime cookingTime)
         {
             _repository.Setup(repository => repository.ExistsCookingTime(cookingTime)).ReturnsAsync(false);
         }
 
         public void ExistsAnyCookingTime()
         {
-            _repository.Setup(repository => repository.ExistsCookingTime(It.IsAny<CookingTimeEnum>())).ReturnsAsync(true);
+            _repository.Setup(repository => repository.ExistsCookingTime(It.IsAny<CookingTime>())).ReturnsAsync(true);
         }
 
         public void DoesNotExistAnyCookingTime()
         {
-            _repository.Setup(repository => repository.ExistsCookingTime(It.IsAny<CookingTimeEnum>())).ReturnsAsync(false);
+            _repository.Setup(repository => repository.ExistsCookingTime(It.IsAny<CookingTime>())).ReturnsAsync(false);
         }
     }
 }

--- a/CommonTestUtilities/Repositories/DifficultyReadOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/DifficultyReadOnlyRepositoryBuilder.cs
@@ -12,24 +12,24 @@ namespace CommonTestUtilities.Repositories
 
         public IDifficultyReadOnlyRepository Build() => _repository.Object;
 
-        public void ExistsDifficulty(DifficultyEnum difficulty)
+        public void ExistsDifficulty(Difficulty difficulty)
         {
             _repository.Setup(repository => repository.ExistsDifficulty(difficulty)).ReturnsAsync(true);
         }
 
-        public void DoesNotExistDifficulty(DifficultyEnum difficulty)
+        public void DoesNotExistDifficulty(Difficulty difficulty)
         {
             _repository.Setup(repository => repository.ExistsDifficulty(difficulty)).ReturnsAsync(false);
         }
 
         public void ExistsAnyDifficulty()
         {
-            _repository.Setup(repository => repository.ExistsDifficulty(It.IsAny<DifficultyEnum>())).ReturnsAsync(true);
+            _repository.Setup(repository => repository.ExistsDifficulty(It.IsAny<Difficulty>())).ReturnsAsync(true);
         }
 
         public void DoesNotExistAnyDifficulty()
         {
-            _repository.Setup(repository => repository.ExistsDifficulty(It.IsAny<DifficultyEnum>())).ReturnsAsync(false);
+            _repository.Setup(repository => repository.ExistsDifficulty(It.IsAny<Difficulty>())).ReturnsAsync(false);
         }
     }
 }

--- a/CommonTestUtilities/Repositories/DishTypeReadOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/DishTypeReadOnlyRepositoryBuilder.cs
@@ -13,24 +13,24 @@ namespace CommonTestUtilities.Repositories
 
         public IDishTypeReadOnlyRepository Build() => _repository.Object;
 
-        public void ExistsDishType(DishTypeEnum dishType)
+        public void ExistsDishType(DishType dishType)
         {
             _repository.Setup(repository => repository.ExistsDishType(dishType)).ReturnsAsync(true);
         }
 
-        public void DoesNotExistDishType(DishTypeEnum dishType)
+        public void DoesNotExistDishType(DishType dishType)
         {
             _repository.Setup(repository => repository.ExistsDishType(dishType)).ReturnsAsync(false);
         }
 
         public void ExistsAnyDishType()
         {
-            _repository.Setup(repository => repository.ExistsDishType(It.IsAny<DishTypeEnum>())).ReturnsAsync(true);
+            _repository.Setup(repository => repository.ExistsDishType(It.IsAny<DishType>())).ReturnsAsync(true);
         }
 
         public void DoesNotExistAnyDishType()
         {
-            _repository.Setup(repository => repository.ExistsDishType(It.IsAny<DishTypeEnum>())).ReturnsAsync(false);
+            _repository.Setup(repository => repository.ExistsDishType(It.IsAny<DishType>())).ReturnsAsync(false);
         }
     }
 }

--- a/CommonTestUtilities/Requests/RequestRecipeJsonBuilder.cs
+++ b/CommonTestUtilities/Requests/RequestRecipeJsonBuilder.cs
@@ -13,10 +13,10 @@ namespace CommonTestUtilities.Requests
 
             return new Faker<RequestRecipeJson>()
                  .RuleFor(r => r.Title, f => f.Lorem.Word())
-                 .RuleFor(r => r.CookingTimeId, f => f.PickRandom<CookingTimeEnum>())
-                 .RuleFor(r => r.DifficultyId, f => f.PickRandom<DifficultyEnum>())
+                 .RuleFor(r => r.CookingTimeId, f => f.PickRandom<CookingTime>())
+                 .RuleFor(r => r.DifficultyId, f => f.PickRandom<Difficulty>())
                  .RuleFor(r => r.Ingredients, f => f.Make(3, () => f.Commerce.ProductName()))
-                 .RuleFor(r => r.DishTypes, f => f.Make(3, () => f.PickRandom<DishTypeEnum>()))
+                 .RuleFor(r => r.DishTypes, f => f.Make(3, () => f.PickRandom<DishType>()))
                  .RuleFor(r => r.Instructions, f => f.Make(3, () => new RequestInstructionJson
                  {
                      Description = f.Lorem.Paragraph(),

--- a/src/backend/MyRecipeBook.Domain/Entities/CookingTimeTypes.cs
+++ b/src/backend/MyRecipeBook.Domain/Entities/CookingTimeTypes.cs
@@ -2,5 +2,5 @@
 
 namespace MyRecipeBook.Domain.Entities
 {
-    public class CookingTime : ReferenceEntityBase<CookingTimeEnum> {}
+    public class CookingTime : ReferenceEntityBase<Enums.CookingTime> {}
 }

--- a/src/backend/MyRecipeBook.Domain/Entities/Difficulty.cs
+++ b/src/backend/MyRecipeBook.Domain/Entities/Difficulty.cs
@@ -1,8 +1,8 @@
-﻿using DifficultyEnum = MyRecipeBook.Domain.Enums.DifficultyEnum;
+﻿using Difficulty = MyRecipeBook.Domain.Enums.Difficulty;
 
 namespace MyRecipeBook.Domain.Entities
 {
-    public class Difficulty : ReferenceEntityBase<DifficultyEnum>
+    public class Difficulty : ReferenceEntityBase<Difficulty>
     {
     }
 }

--- a/src/backend/MyRecipeBook.Domain/Entities/DishTypes.cs
+++ b/src/backend/MyRecipeBook.Domain/Entities/DishTypes.cs
@@ -2,5 +2,5 @@
 
 namespace MyRecipeBook.Domain.Entities
 {
-    public class DishTypes : ReferenceEntityBase<DishTypeEnum> {}
+    public class DishTypes : ReferenceEntityBase<DishType> {}
 }

--- a/src/backend/MyRecipeBook.Domain/Entities/Recipe.cs
+++ b/src/backend/MyRecipeBook.Domain/Entities/Recipe.cs
@@ -5,8 +5,8 @@ namespace MyRecipeBook.Domain.Entities
     public class Recipe : EntityBase
     {
         public string Title { get; set; } = string.Empty;
-        public CookingTimeEnum? CookingTimeId { get; set; }
-        public DifficultyEnum? DifficultyId { get; set; }
+        public Enums.CookingTime? CookingTimeId { get; set; }
+        public Enums.Difficulty? DifficultyId { get; set; }
         public IList<Ingredient> Ingredients { get; set; } = [];
         public IList<Instruction> Instructions { get; set; } = [];
         public IList<RecipesDishTypes> RecipeDishTypes { get; set; } = [];

--- a/src/backend/MyRecipeBook.Domain/Entities/RecipesDishTypes.cs
+++ b/src/backend/MyRecipeBook.Domain/Entities/RecipesDishTypes.cs
@@ -7,7 +7,7 @@ namespace MyRecipeBook.Domain.Entities
         public long RecipeId { get; set; }
         public Recipe Recipe { get; set; } = default!;
 
-        public DishTypeEnum DishTypeId { get; set; }
+        public DishType DishTypeId { get; set; }
         public DishTypes DishType { get; set; } = default!;
 
     }

--- a/src/backend/MyRecipeBook.Domain/Enums/CookingTime.cs
+++ b/src/backend/MyRecipeBook.Domain/Enums/CookingTime.cs
@@ -1,6 +1,6 @@
-﻿namespace MyRecipeBook.Communication.Enums
+﻿namespace MyRecipeBook.Domain.Enums
 {
-    public enum CookingTimeEnum
+    public enum CookingTime
     {
         Less_10_Minutes = 1,
         Between_10_30_Minutes = 2,

--- a/src/backend/MyRecipeBook.Domain/Enums/Difficulty.cs
+++ b/src/backend/MyRecipeBook.Domain/Enums/Difficulty.cs
@@ -1,6 +1,6 @@
 ﻿namespace MyRecipeBook.Domain.Enums
 {
-    public enum DifficultyEnum
+    public enum Difficulty
     {
         Low = 1,
         Medium = 2,

--- a/src/backend/MyRecipeBook.Domain/Enums/DishType.cs
+++ b/src/backend/MyRecipeBook.Domain/Enums/DishType.cs
@@ -1,6 +1,6 @@
 ﻿namespace MyRecipeBook.Domain.Enums
 {
-    public enum DishTypeEnum
+    public enum DishType
     {
         Breakfast = 1,
         Lunch = 2,

--- a/src/backend/MyRecipeBook.Domain/Repositories/CookingTime/ICookingTimeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/CookingTime/ICookingTimeReadOnlyRepository.cs
@@ -4,6 +4,6 @@ namespace MyRecipeBook.Domain.Repositories.CookingTime
 {
     public interface ICookingTimeReadOnlyRepository
     {
-        Task<bool> ExistsCookingTime(CookingTimeEnum cookingTime);
+        Task<bool> ExistsCookingTime(Enums.CookingTime cookingTime);
     }
 }

--- a/src/backend/MyRecipeBook.Domain/Repositories/Difficulty/IDifficultyReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/Difficulty/IDifficultyReadOnlyRepository.cs
@@ -4,6 +4,6 @@ namespace MyRecipeBook.Domain.Repositories.Difficulty
 {
     public interface IDifficultyReadOnlyRepository
     {
-        Task<bool> ExistsDifficulty(DifficultyEnum difficulty);
+        Task<bool> ExistsDifficulty(Enums.Difficulty difficulty);
     }
 }

--- a/src/backend/MyRecipeBook.Domain/Repositories/DishType/IDishTypeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/DishType/IDishTypeReadOnlyRepository.cs
@@ -4,7 +4,7 @@ namespace MyRecipeBook.Domain.Repositories.DishType
 {
     public interface IDishTypeReadOnlyRepository
     {
-        Task<bool> ExistsDishType(DishTypeEnum dishType);
-        Task<List<DishTypeEnum>> GetExistingDishTypes(IEnumerable<DishTypeEnum> dishTypes);
+        Task<bool> ExistsDishType(Enums.DishType dishType);
+        Task<List<Enums.DishType>> GetExistingDishTypes(IEnumerable<Enums.DishType> dishTypes);
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/CookingTimeRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/CookingTimeRepository.cs
@@ -6,7 +6,7 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 {
     public class CookingTimeRepository(MyRecipeBookDbContext dbContext) : ICookingTimeReadOnlyRepository
     {
-        public async Task<bool> ExistsCookingTime(CookingTimeEnum cookingTime)
+        public async Task<bool> ExistsCookingTime(CookingTime cookingTime)
         {
             return await dbContext.CookingTime.AnyAsync(ct => ct.Id == cookingTime);
         }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/DifficultyRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/DifficultyRepository.cs
@@ -6,9 +6,9 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 {
     public class DifficultyRepository(MyRecipeBookDbContext dbContext) : IDifficultyReadOnlyRepository
     {
-        public async Task<bool> ExistsDifficulty(DifficultyEnum difficulty)
+        public async Task<bool> ExistsDifficulty(Difficulty difficulty)
         {
-            return await dbContext.Difficulty.AnyAsync(d => d.Id == difficulty);
+            return await dbContext.Difficulty.AnyAsync((System.Linq.Expressions.Expression<Func<Domain.Entities.Difficulty, bool>>)(d => d.Id == difficulty));
 
         }
     }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/DishTypesRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/DishTypesRepository.cs
@@ -7,13 +7,13 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 {
     public class DishTypesRepository(MyRecipeBookDbContext _dbContext) : IDishTypeReadOnlyRepository
     {
-        public async Task<bool> ExistsDishType(DishTypeEnum dishType)
+        public async Task<bool> ExistsDishType(DishType dishType)
         {
             return await _dbContext.DishTypes
                  .AnyAsync(d => d.Id == dishType);
         }
 
-        public async Task<List<DishTypeEnum>> GetExistingDishTypes(IEnumerable<DishTypeEnum> dishTypes)
+        public async Task<List<DishType>> GetExistingDishTypes(IEnumerable<DishType> dishTypes)
         {
             return await _dbContext.DishTypes
                 .Where(dt => dishTypes.Contains(dt.Id))

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Mappers/CookingTimeMapper.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Mappers/CookingTimeMapper.cs
@@ -4,16 +4,16 @@ namespace MyRecipeBook.Application.Mappers
 {
     public static class CookingTimeMapper
     {
-        public static Domain.Enums.CookingTimeEnum ToDomain(
-            Communication.Enums.CookingTimeEnum communicationEnum)
+        public static Domain.Enums.CookingTime ToDomain(
+            Communication.Enums.CookingTime communicationEnum)
         {
 
             return communicationEnum switch
             {
-                Communication.Enums.CookingTimeEnum.Less_10_Minutes => Domain.Enums.CookingTimeEnum.Less_10_Minutes,
-                Communication.Enums.CookingTimeEnum.Between_10_30_Minutes => Domain.Enums.CookingTimeEnum.Between_10_30_Minutes,
-                Communication.Enums.CookingTimeEnum.Between_30_60_Minutes => Domain.Enums.CookingTimeEnum.Between_30_60_Minutes,
-                Communication.Enums.CookingTimeEnum.Greather_60_Minutes => Domain.Enums.CookingTimeEnum.Greather_60_Minutes,
+                Communication.Enums.CookingTime.Less_10_Minutes => Domain.Enums.CookingTime.Less_10_Minutes,
+                Communication.Enums.CookingTime.Between_10_30_Minutes => Domain.Enums.CookingTime.Between_10_30_Minutes,
+                Communication.Enums.CookingTime.Between_30_60_Minutes => Domain.Enums.CookingTime.Between_30_60_Minutes,
+                Communication.Enums.CookingTime.Greather_60_Minutes => Domain.Enums.CookingTime.Greather_60_Minutes,
                 _ => throw new InvalidOperationException(ResourceMessageHelper.FieldNotSupported("CookingTime"))
             };
         }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Mappers/DifficultyMapper.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Mappers/DifficultyMapper.cs
@@ -4,14 +4,14 @@ namespace MyRecipeBook.Application.Mappers
 {
     public static class DifficultyMapper
     {
-        public static Domain.Enums.DifficultyEnum ToDomain(
-            Communication.Enums.DifficultyEnum difficultyEnum)
+        public static Domain.Enums.Difficulty ToDomain(
+            Communication.Enums.Difficulty difficultyEnum)
         {
             return difficultyEnum switch
             {
-                Communication.Enums.DifficultyEnum.Low => Domain.Enums.DifficultyEnum.Low,
-                Communication.Enums.DifficultyEnum.Medium => Domain.Enums.DifficultyEnum.Medium,
-                Communication.Enums.DifficultyEnum.High => Domain.Enums.DifficultyEnum.High,
+                Communication.Enums.Difficulty.Low => Domain.Enums.Difficulty.Low,
+                Communication.Enums.Difficulty.Medium => Domain.Enums.Difficulty.Medium,
+                Communication.Enums.Difficulty.High => Domain.Enums.Difficulty.High,
                 _ => throw new InvalidOperationException(ResourceMessageHelper.FieldNotSupported("Difficulty"))
             };
         }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Mappers/DishTypesMapper.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Mappers/DishTypesMapper.cs
@@ -4,18 +4,18 @@ namespace MyRecipeBook.Application.Mappers
 {
     public static class DishTypesMapper
     {
-        public static Domain.Enums.DishTypeEnum ToDomain(
-            Communication.Enums.DishTypeEnum dishType)
+        public static Domain.Enums.DishType ToDomain(
+            Communication.Enums.DishType dishType)
         {
             return dishType switch
             {
-                Communication.Enums.DishTypeEnum.Snack => Domain.Enums.DishTypeEnum.Snack,
-                Communication.Enums.DishTypeEnum.Lunch => Domain.Enums.DishTypeEnum.Lunch,
-                Communication.Enums.DishTypeEnum.Appertizers => Domain.Enums.DishTypeEnum.Appertizers,
-                Communication.Enums.DishTypeEnum.Breakfast => Domain.Enums.DishTypeEnum.Breakfast,
-                Communication.Enums.DishTypeEnum.Drinks => Domain.Enums.DishTypeEnum.Drinks,
-                Communication.Enums.DishTypeEnum.Dessert => Domain.Enums.DishTypeEnum.Dessert,
-                Communication.Enums.DishTypeEnum.Dinner => Domain.Enums.DishTypeEnum.Dinner,
+                Communication.Enums.DishType.Snack => Domain.Enums.DishType.Snack,
+                Communication.Enums.DishType.Lunch => Domain.Enums.DishType.Lunch,
+                Communication.Enums.DishType.Appertizers => Domain.Enums.DishType.Appertizers,
+                Communication.Enums.DishType.Breakfast => Domain.Enums.DishType.Breakfast,
+                Communication.Enums.DishType.Drinks => Domain.Enums.DishType.Drinks,
+                Communication.Enums.DishType.Dessert => Domain.Enums.DishType.Dessert,
+                Communication.Enums.DishType.Dinner => Domain.Enums.DishType.Dinner,
                 _ => throw new InvalidOperationException(ResourceMessageHelper.FieldNotSupported("DishType"))
             };
         }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Services/AutoMapper/AutoMapping.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Services/AutoMapper/AutoMapping.cs
@@ -41,7 +41,7 @@ namespace MyRecipeBook.Application.Services.AutoMapper
                     dest.Item, opt => opt.MapFrom(src => src)
                 );
 
-            CreateMap<DishTypeEnum, Domain.Entities.DishTypes>()
+            CreateMap<DishType, Domain.Entities.DishTypes>()
                 .ForMember(dest =>
                     dest.Id, opt => opt.MapFrom(src => src)
                 );
@@ -49,7 +49,7 @@ namespace MyRecipeBook.Application.Services.AutoMapper
             CreateMap<RequestInstructionJson, Domain.Entities.Instruction>()
                 .ForMember(dest => dest.RecipeId, opt => opt.Ignore());
 
-            CreateMap<DishTypeEnum, Domain.Entities.RecipesDishTypes>()
+            CreateMap<DishType, Domain.Entities.RecipesDishTypes>()
                 .ForMember(dest => dest.DishTypeId, opt => opt.MapFrom(src => src))
                 .ForMember(dest => dest.RecipeId, opt => opt.Ignore())
                 .ForMember(dest => dest.Recipe, opt => opt.Ignore())

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/RecipeValidator.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/RecipeValidator.cs
@@ -7,109 +7,112 @@ using MyRecipeBook.Domain.Repositories.Difficulty;
 using MyRecipeBook.Domain.Repositories.DishType;
 using MyRecipeBook.Exceptions.ExceptionsBase;
 
-public class RecipeValidator : AbstractValidator<RequestRecipeJson>
+namespace MyRecipeBook.Application.UseCases.Recipe
 {
-    private readonly ICookingTimeReadOnlyRepository _cookingTimeReadOnlyRepository;
-    private readonly IDifficultyReadOnlyRepository _difficultyReadOnlyRepository;
-    private readonly IDishTypeReadOnlyRepository _dishTypeReadOnlyRepository;
-
-    public RecipeValidator(
-        ICookingTimeReadOnlyRepository cookingTimeReadOnlyRepository,
-        IDifficultyReadOnlyRepository difficultyReadOnlyRepository,
-        IDishTypeReadOnlyRepository dishTypeReadOnlyRepository)
+    public class RecipeValidator : AbstractValidator<RequestRecipeJson>
     {
-        _cookingTimeReadOnlyRepository = cookingTimeReadOnlyRepository;
-        _difficultyReadOnlyRepository = difficultyReadOnlyRepository;
-        _dishTypeReadOnlyRepository = dishTypeReadOnlyRepository;
+        private readonly ICookingTimeReadOnlyRepository _cookingTimeReadOnlyRepository;
+        private readonly IDifficultyReadOnlyRepository _difficultyReadOnlyRepository;
+        private readonly IDishTypeReadOnlyRepository _dishTypeReadOnlyRepository;
 
-        RuleFor(recipe => recipe.Title)
-            .SetValidator(new StringValidator<RequestRecipeJson>("Title", 100));
+        public RecipeValidator(
+            ICookingTimeReadOnlyRepository cookingTimeReadOnlyRepository,
+            IDifficultyReadOnlyRepository difficultyReadOnlyRepository,
+            IDishTypeReadOnlyRepository dishTypeReadOnlyRepository)
+        {
+            _cookingTimeReadOnlyRepository = cookingTimeReadOnlyRepository;
+            _difficultyReadOnlyRepository = difficultyReadOnlyRepository;
+            _dishTypeReadOnlyRepository = dishTypeReadOnlyRepository;
 
-        RuleFor(recipe => recipe.CookingTimeId)
-            .Cascade(CascadeMode.Stop)
-            .IsInEnum()
-            .WithMessage(ResourceMessageHelper.FieldNotSupported("CookingTime"))
-            .MustAsync(async (cookingTime, cancellation) =>
-            {
-                if (cookingTime == null) return true;
+            RuleFor(recipe => recipe.Title)
+                .SetValidator(new StringValidator<RequestRecipeJson>("Title", 100));
 
-                try
+            RuleFor(recipe => recipe.CookingTimeId)
+                .Cascade(CascadeMode.Stop)
+                .IsInEnum()
+                .WithMessage(ResourceMessageHelper.FieldNotSupported("CookingTime"))
+                .MustAsync(async (cookingTime, cancellation) =>
                 {
-                    var domainCookingTime = CookingTimeMapper.ToDomain(cookingTime.Value);
-                    return await _cookingTimeReadOnlyRepository.ExistsCookingTime(domainCookingTime);
-                }
-                catch (InvalidOperationException)
+                    if (cookingTime == null) return true;
+
+                    try
+                    {
+                        var domainCookingTime = CookingTimeMapper.ToDomain(cookingTime.Value);
+                        return await _cookingTimeReadOnlyRepository.ExistsCookingTime(domainCookingTime);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return false;
+                    }
+
+
+                })
+                .WithMessage(ResourceMessageHelper.FieldEmpty("CookingTime"));
+
+            RuleFor(recipe => recipe.DifficultyId)
+                .Cascade(CascadeMode.Stop)
+                .IsInEnum()
+                .WithMessage(ResourceMessageHelper.FieldNotSupported("Difficulty"))
+                .MustAsync(async (difficulty, cancellation) =>
                 {
-                    return false;
-                }
+                    if (difficulty == null) return true;
 
+                    try
+                    {
+                        var domainDifficulty = DifficultyMapper.ToDomain(difficulty.Value);
+                        return await _difficultyReadOnlyRepository.ExistsDifficulty(domainDifficulty);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return false;
+                    }
 
-            })
-            .WithMessage(ResourceMessageHelper.FieldEmpty("CookingTime"));
+                })
+                .WithMessage(ResourceMessageHelper.FieldNotSupported("Difficulty"));
 
-        RuleFor(recipe => recipe.DifficultyId)
-            .Cascade(CascadeMode.Stop)
-            .IsInEnum()
-            .WithMessage(ResourceMessageHelper.FieldNotSupported("Difficulty"))
-            .MustAsync(async (difficulty, cancellation) =>
-            {
-                if (difficulty == null) return true;
+            RuleFor(recipe => recipe.Ingredients.Count)
+                .GreaterThan(0)
+                .WithMessage(ResourceMessageHelper.FieldMustHaveAtLeastOne("Ingredients"));
 
-                try
+            RuleFor(recipe => recipe.Instructions.Count)
+                .GreaterThan(0)
+                .WithMessage(ResourceMessageHelper.FieldMustHaveAtLeastOne("Instructions"));
+
+            RuleForEach(recipe => recipe.DishTypes)
+                .Cascade(CascadeMode.Stop)
+                .IsInEnum()
+                .WithMessage(ResourceMessageHelper.FieldNotSupported("DishTypes"))
+                .MustAsync(async (dishType, cancellation) =>
                 {
-                    var domainDifficulty = DifficultyMapper.ToDomain(difficulty.Value);
-                    return await _difficultyReadOnlyRepository.ExistsDifficulty(domainDifficulty);
-                }
-                catch (InvalidOperationException)
+                    try
+                    {
+                        var domainDishType = DishTypesMapper.ToDomain(dishType);
+                        return await _dishTypeReadOnlyRepository.ExistsDishType(domainDishType);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        return false;
+                    }
+                })
+                .WithMessage(ResourceMessageHelper.FieldNotSupported("DishTypes"));
+
+            RuleForEach(recipe => recipe.Ingredients)
+                .SetValidator(new StringValidator<RequestRecipeJson>("Ingredients", 100));
+
+            RuleForEach(recipe => recipe.Instructions)
+                .ChildRules(instructionRule =>
                 {
-                    return false;
-                }
+                    instructionRule.RuleFor(instruction => instruction.Step)
+                        .GreaterThan(0)
+                        .WithMessage(ResourceMessageHelper.FieldNonNegative("Instructions - Step"));
 
-            })
-            .WithMessage(ResourceMessageHelper.FieldNotSupported("Difficulty"));
+                    instructionRule.RuleFor(instruction => instruction.Description)
+                        .SetValidator(new StringValidator<RequestInstructionJson>("Instructions - Description", 2000));
+                });
 
-        RuleFor(recipe => recipe.Ingredients.Count)
-            .GreaterThan(0)
-            .WithMessage(ResourceMessageHelper.FieldMustHaveAtLeastOne("Ingredients"));
-
-        RuleFor(recipe => recipe.Instructions.Count)
-            .GreaterThan(0)
-            .WithMessage(ResourceMessageHelper.FieldMustHaveAtLeastOne("Instructions"));
-
-        RuleForEach(recipe => recipe.DishTypes)
-            .Cascade(CascadeMode.Stop)
-            .IsInEnum()
-            .WithMessage(ResourceMessageHelper.FieldNotSupported("DishTypes"))
-            .MustAsync(async (dishType, cancellation) =>
-            {
-                try
-                {
-                    var domainDishType = DishTypesMapper.ToDomain(dishType);
-                    return await _dishTypeReadOnlyRepository.ExistsDishType(domainDishType);
-                }
-                catch (InvalidOperationException)
-                {
-                    return false;
-                }
-            })
-            .WithMessage(ResourceMessageHelper.FieldNotSupported("DishTypes"));
-
-        RuleForEach(recipe => recipe.Ingredients)
-            .SetValidator(new StringValidator<RequestRecipeJson>("Ingredients", 100));
-
-        RuleForEach(recipe => recipe.Instructions)
-            .ChildRules(instructionRule =>
-            {
-                instructionRule.RuleFor(instruction => instruction.Step)
-                    .GreaterThan(0)
-                    .WithMessage(ResourceMessageHelper.FieldNonNegative("Instructions - Step"));
-
-                instructionRule.RuleFor(instruction => instruction.Description)
-                    .SetValidator(new StringValidator<RequestInstructionJson>("Instructions - Description", 2000));
-            });
-
-        RuleFor(recipe => recipe.Instructions)
-            .Must(instructions => instructions.Select(i => i.Step).Distinct().Count() == instructions.Count)
-            .WithMessage(ResourceMessageHelper.FieldTwoOrMore("Instructions - Step"));
+            RuleFor(recipe => recipe.Instructions)
+                .Must(instructions => instructions.Select(i => i.Step).Distinct().Count() == instructions.Count)
+                .WithMessage(ResourceMessageHelper.FieldTwoOrMore("Instructions - Step"));
+        }
     }
 }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
@@ -14,7 +14,6 @@ namespace MyRecipeBook.Application.UseCases.Recipe.Register
     public class RegisterRecipeUseCase : IRegisterRecipeUseCase
     {
         private readonly IRecipeWriteOnlyRepository _repository;
-        //private readonly IRecipesDishTypeWriteOnlyRepository _recipesDishTypeWriteOnlyRepository;
 
         private readonly ICookingTimeReadOnlyRepository _repositoryCookingTime;
         private readonly IDifficultyReadOnlyRepository _repositoryDifficultyTime;
@@ -59,13 +58,6 @@ namespace MyRecipeBook.Application.UseCases.Recipe.Register
             recipe.Instructions = _mapper.Map<IList<Domain.Entities.Instruction>>(instructions);
 
             recipe.RecipeDishTypes = _mapper.Map<IList<Domain.Entities.RecipesDishTypes>>(request.DishTypes);
-
-            //var recipesDishTypes = request.DishTypes.Select(dishType => new Domain.Entities.RecipesDishTypes
-            //{
-            //    DishTypeId = DishTypesMapper.ToDomain(dishType)
-            //}).ToList();
-
-            //recipe.RecipeDishTypes = recipesDishTypes;
 
             await _repository.Add(recipe);
 

--- a/src/shared/MyRecipeBook.Communucation/Enums/CookingTime.cs
+++ b/src/shared/MyRecipeBook.Communucation/Enums/CookingTime.cs
@@ -1,6 +1,6 @@
-﻿namespace MyRecipeBook.Domain.Enums
+﻿namespace MyRecipeBook.Communication.Enums
 {
-    public enum CookingTimeEnum
+    public enum CookingTime
     {
         Less_10_Minutes = 1,
         Between_10_30_Minutes = 2,

--- a/src/shared/MyRecipeBook.Communucation/Enums/Difficulty.cs
+++ b/src/shared/MyRecipeBook.Communucation/Enums/Difficulty.cs
@@ -1,6 +1,6 @@
 ﻿namespace MyRecipeBook.Communication.Enums
 {
-    public enum DifficultyEnum
+    public enum Difficulty
     {
         Low = 1,
         Medium = 2,

--- a/src/shared/MyRecipeBook.Communucation/Enums/DishType.cs
+++ b/src/shared/MyRecipeBook.Communucation/Enums/DishType.cs
@@ -1,6 +1,6 @@
 ﻿namespace MyRecipeBook.Communication.Enums
 {
-    public enum DishTypeEnum
+    public enum DishType
     {
         Breakfast = 1,
         Lunch = 2,

--- a/src/shared/MyRecipeBook.Communucation/Request/RequestRecipeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Request/RequestRecipeJson.cs
@@ -5,10 +5,10 @@ namespace MyRecipeBook.Communication.Request
     public class RequestRecipeJson
     {
         public string Title { get; set; } = string.Empty;
-        public CookingTimeEnum? CookingTimeId { get; set; }
-        public DifficultyEnum? DifficultyId { get; set; }
+        public CookingTime? CookingTimeId { get; set; }
+        public Difficulty? DifficultyId { get; set; }
         public IList<string> Ingredients { get; set; } = [];
         public IList<RequestInstructionJson> Instructions { get; set; } = [];
-        public IList<DishTypeEnum> DishTypes { get; set; } = [];
+        public IList<DishType> DishTypes { get; set; } = [];
     }
 }

--- a/tests/Validators.Test/Recipe/RecipeValidatorTest.cs
+++ b/tests/Validators.Test/Recipe/RecipeValidatorTest.cs
@@ -1,5 +1,6 @@
 using CommonTestUtilities.Repositories;
 using CommonTestUtilities.Requests;
+using MyRecipeBook.Application.UseCases.Recipe;
 using MyRecipeBook.Communication.Enums;
 using MyRecipeBook.Exceptions.ExceptionsBase;
 using Shouldly;
@@ -57,7 +58,7 @@ public class RecipeValidatorTest
         var validator = CreateValidator();
 
         var request = RequestRecipeJsonBuilder.Build();
-        request.CookingTimeId = (MyRecipeBook.Communication.Enums.CookingTimeEnum?)1000;
+        request.CookingTimeId = (MyRecipeBook.Communication.Enums.CookingTime?)1000;
 
         var result = await validator.ValidateAsync(request);
 
@@ -74,7 +75,7 @@ public class RecipeValidatorTest
         );
 
         var request = RequestRecipeJsonBuilder.Build();
-        request.CookingTimeId = (MyRecipeBook.Communication.Enums.CookingTimeEnum?)1000;
+        request.CookingTimeId = (MyRecipeBook.Communication.Enums.CookingTime?)1000;
 
         var result = await validator.ValidateAsync(request);
 
@@ -102,7 +103,7 @@ public class RecipeValidatorTest
         var validator = CreateValidator();
 
         var request = RequestRecipeJsonBuilder.Build();
-        request.DifficultyId = (MyRecipeBook.Communication.Enums.DifficultyEnum?)1000;
+        request.DifficultyId = (MyRecipeBook.Communication.Enums.Difficulty?)1000;
 
         var result = await validator.ValidateAsync(request);
 
@@ -119,7 +120,7 @@ public class RecipeValidatorTest
         );
 
         var request = RequestRecipeJsonBuilder.Build();
-        request.DifficultyId = (MyRecipeBook.Communication.Enums.DifficultyEnum?)1000;
+        request.DifficultyId = (MyRecipeBook.Communication.Enums.Difficulty?)1000;
 
         var result = await validator.ValidateAsync(request);
 
@@ -212,7 +213,7 @@ public class RecipeValidatorTest
         var validator = CreateValidator();
 
         var request = RequestRecipeJsonBuilder.Build();
-        request.DishTypes.Add((DishTypeEnum)1000);
+        request.DishTypes.Add((DishType)1000);
 
         var result = await validator.ValidateAsync(request);
 


### PR DESCRIPTION
Rename enums by removing `Enum` suffix and update references

- Replaced `CookingTimeEnum`, `DifficultyEnum`, and `DishTypeEnum` with `CookingTime`, `Difficulty`, and `DishType` respectively.
- Updated all usages across domain entities, DTOs, validators, repositories, and application logic.
- Refactored enum mapping logic in mappers and validators to handle the renamed types.
- Adjusted tests and mocks to use the new enum names and ensure validation correctness.
- Improves clarity and aligns naming with best practices.
