### PR TITLE
Feature/recipe tests

### DIFF
--- a/CommonTestUtilities/CommonTestUtilities.csproj
+++ b/CommonTestUtilities/CommonTestUtilities.csproj
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="14.0.0" />
     <PackageReference Include="Bogus" Version="35.6.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
 

--- a/CommonTestUtilities/Requests/RequestRecipeJsonBuilder.cs
+++ b/CommonTestUtilities/Requests/RequestRecipeJsonBuilder.cs
@@ -16,7 +16,7 @@ namespace CommonTestUtilities.Requests
                  .RuleFor(r => r.CookingTimeId, f => f.PickRandom<RecipeCookingTime>())
                  .RuleFor(r => r.DifficultyId, f => f.PickRandom<RecipeDifficulty>())
                  .RuleFor(r => r.Ingredients, f => f.Make(3, () => f.Commerce.ProductName()))
-                 .RuleFor(r => r.DishTypes, f => f.Make(3, () => f.PickRandom<RecipeDishType>()))
+                 .RuleFor(r => r.DishTypes, f => f.Random.EnumValues<RecipeDishType>().Take(3).ToList())
                  .RuleFor(r => r.Instructions, f => f.Make(3, () => new RequestInstructionJson
                  {
                      Description = f.Lorem.Paragraph(),

--- a/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
@@ -12,7 +12,7 @@ namespace MyRecipeBook.API.Controllers
     public class RecipeController : MyRecipeBookBaseController
     {
         [HttpPost]
-        [ProducesResponseType(typeof(ResponseRegisteredUserJson), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ResponseRegisteredRecipeJson), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Register(
             [FromServices] IRegisterRecipeUseCase useCase,

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -28,13 +28,14 @@ builder.Services.AddSwaggerGen(c =>
     c.UseAllOfToExtendReferenceSchemas();
     c.AddSecurityDefinition(_bearer, new OpenApiSecurityScheme()
     {
+        Name = "Authorization",
+        Type = SecuritySchemeType.ApiKey,
+        Scheme = _bearer,
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
         Description = "JWT Authorization header using the Bearer scheme." +
         "Enter 'Bearer' [space] and then your token in the text input below." +
         "Example: 'Bearer 12345abcdef'",
-        Name = "Authorization",
-        In = ParameterLocation.Header,
-        Type = SecuritySchemeType.ApiKey,
-        Scheme = _bearer,
 
     });
     c.AddSecurityRequirement(new OpenApiSecurityRequirement

--- a/tests/WebApi.test/Login/DoLogin/DoLoginTest.cs
+++ b/tests/WebApi.test/Login/DoLogin/DoLoginTest.cs
@@ -12,7 +12,7 @@ namespace WebApi.test.Login.DoLogin
     public class DoLoginTest : MyRecipeBookClassFixture
     {
 
-        private readonly string _method = "login";
+        private readonly string METHOD = "login";
 
         private readonly string _email;
         private readonly string _password;
@@ -34,7 +34,7 @@ namespace WebApi.test.Login.DoLogin
                 Password = _password
             };
 
-            var response = await DoPost(_method, request);
+            var response = await DoPost(METHOD, request);
 
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
 
@@ -59,7 +59,7 @@ namespace WebApi.test.Login.DoLogin
         {
             var request = RequestLoginJsonBuilder.Build();
 
-            var response = await DoPost(_method, request, culture);
+            var response = await DoPost(METHOD, request, culture);
 
             response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
 

--- a/tests/WebApi.test/User/Register/RegisterUserTest.cs
+++ b/tests/WebApi.test/User/Register/RegisterUserTest.cs
@@ -12,7 +12,7 @@ namespace WebApi.test.User.Register
     {
 
 
-        private readonly string _method = "user";
+        private readonly string METHOD = "user";
         public RegisterUserTest(CustomWebApplicationFactory factory) : base(factory) { }
 
         [Fact]
@@ -20,7 +20,7 @@ namespace WebApi.test.User.Register
         {
             var request = RequestRegisterUserJsonBuilder.Build();
 
-            var response = await DoPost(_method, request);
+            var response = await DoPost(METHOD, request);
 
             response.StatusCode.ShouldBe(HttpStatusCode.Created);
 
@@ -48,7 +48,7 @@ namespace WebApi.test.User.Register
             request.Name = string.Empty;
 
 
-            var response = await DoPost(_method, request, culture);
+            var response = await DoPost(METHOD, request, culture);
 
             response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
 

--- a/tests/WebApi.test/User/Update/UpdateUserInvalidTokenTest.cs
+++ b/tests/WebApi.test/User/Update/UpdateUserInvalidTokenTest.cs
@@ -1,12 +1,7 @@
 ﻿using CommonTestUtilities.Requests;
 using CommonTestUtilities.Tokens;
-using MyRecipeBook.Exceptions;
 using Shouldly;
-using System.Globalization;
 using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json;
-using WebApi.test.InlineData;
 
 namespace WebApi.test.User.Update
 {


### PR DESCRIPTION
Improve test coverage, Swagger docs, and naming consistency

- Replaced `Faker.Make` with `Random.EnumValues().Take(3)` to better simulate enum collections.
- Corrected Swagger `AddSecurityDefinition` property order for clarity and consistency.
- Fixed `[ProducesResponseType]` for recipe registration to reflect correct response type.
- Added new tests for successful recipe registration and token validation scenarios.
- Renamed `_method` field to `METHOD` in test classes to align with constant naming conventions.
