### PR TITLE
Implement recipe filtering API and infrastructure

### DIFF
--- a/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
@@ -1,9 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using MyRecipeBook.API.Attributes;
+using MyRecipeBook.Application.UseCases.Recipe.Filter;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
 using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Response;
-using MyRecipeBook.Communication.Responses;
 
 namespace MyRecipeBook.API.Controllers
 
@@ -23,5 +23,22 @@ namespace MyRecipeBook.API.Controllers
 
             return Created(string.Empty, response);
         }
+
+        [HttpPost("filter")]
+        [ProducesResponseType(typeof(ResponseRecipesJson), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> Filter(
+            [FromServices] IFilterRecipeUseCase useCase,
+            [FromBody] RequestFilterRecipeJson request
+       )
+        {
+            var response = await useCase.Execute(request);
+
+            if (response.Recipes.Any()) 
+                return Ok(response);
+
+            return NoContent();
+        }
     }
+
 }

--- a/src/backend/MyRecipeBook.Domain/Dtos/FilterRecipesDto.cs
+++ b/src/backend/MyRecipeBook.Domain/Dtos/FilterRecipesDto.cs
@@ -1,0 +1,12 @@
+﻿using MyRecipeBook.Domain.Enums;
+
+namespace MyRecipeBook.Domain.Dtos
+{
+    public record FilterRecipesDto
+    {
+        public string? RecipeTitle_Ingredient {  get; init; }
+        public IList<RecipeCookingTime> CookingTimes { get; init; } = [];
+        public IList<RecipeDifficulty> Difficulties { get; init; } = [];
+        public IList<RecipeDishType> DishTypes { get; init; } = [];
+    }
+}

--- a/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
@@ -1,0 +1,9 @@
+﻿using MyRecipeBook.Domain.Dtos;
+
+namespace MyRecipeBook.Domain.Repositories.Recipe
+{
+    public interface IRecipeReadOnlyRepository
+    {
+        Task<IList<Entities.Recipe>> Filter(Entities.User user, FilterRecipesDto filters);
+    }
+}

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
@@ -1,9 +1,12 @@
-﻿using MyRecipeBook.Domain.Entities;
+﻿using Microsoft.EntityFrameworkCore;
+using MyRecipeBook.Domain.Dtos;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Extension;
 using MyRecipeBook.Domain.Repositories.Recipe;
 
 namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 {
-    public class RecipeRepository : IRecipeWriteOnlyRepository
+    public class RecipeRepository : IRecipeWriteOnlyRepository, IRecipeReadOnlyRepository
     {
         private readonly MyRecipeBookDbContext _dbContext;
 
@@ -11,5 +14,36 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 
         public async Task Add(Recipe recipe) => await _dbContext.Recipes.AddAsync(recipe);
 
+        public async Task<IList<Recipe>> Filter(User user, FilterRecipesDto filters)
+        {
+           var query = _dbContext
+                .Recipes
+                .AsNoTracking()
+                .Include(recipe => recipe.Ingredients)
+                .Where(recipe => recipe.Active && recipe.UserId == user.Id);
+
+            if (filters.Difficulties.Any())
+            {
+                query = query.Where(recipe => recipe.DifficultyId.HasValue && filters.Difficulties.Contains(recipe.DifficultyId.Value));
+            }
+
+            if (filters.CookingTimes.Any())
+            {
+                query = query.Where(recipe => recipe.CookingTimeId.HasValue && filters.CookingTimes.Contains(recipe.CookingTimeId.Value));
+            }
+
+            if (filters.DishTypes.Any())
+            {
+                query = query.Where(recipe => recipe.RecipeDishTypes.Any(dishtype => filters.DishTypes.Contains(dishtype.DishTypeId)));
+            }
+
+            if (filters.RecipeTitle_Ingredient.NotEmpty())
+            {
+                query = query.Where(recipe => recipe.Title.Contains(filters.RecipeTitle_Ingredient) 
+                || recipe.Ingredients.Any(ingredient => ingredient.Item.Contains(filters.RecipeTitle_Ingredient)));
+            }
+
+            return await query.ToListAsync();
+        }
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
@@ -62,6 +62,8 @@ namespace MyRecipeBook.Infrastructure
             services.AddScoped<IDishTypeReadOnlyRepository, DishTypesRepository>();
 
             services.AddScoped<IRecipeWriteOnlyRepository, RecipeRepository>();
+            services.AddScoped<IRecipeReadOnlyRepository, RecipeRepository>();
+
             services.AddScoped<IRecipesDishTypeWriteOnlyRepository, RecipesDishTypeRepository>();
         }
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using MyRecipeBook.Application.Services.AutoMapper;
 using MyRecipeBook.Application.UseCases.Login.DoLogin;
+using MyRecipeBook.Application.UseCases.Recipe.Filter;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
 using MyRecipeBook.Application.UseCases.User.ChangePassword;
 using MyRecipeBook.Application.UseCases.User.Profile;
@@ -47,6 +48,7 @@ namespace MyRecipeBook.Application
             services.AddScoped<IUpdateUserUseCase, UpdateUserUseCase>();
             services.AddScoped<IChangePasswordUseCase, ChangePasswordUseCase>();
             services.AddScoped<IRegisterRecipeUseCase, RegisterRecipeUseCase>();
+            services.AddScoped<IFilterRecipeUseCase, FilterRecipeUseCase>();
         }
 
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Services/AutoMapper/AutoMapping.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Services/AutoMapper/AutoMapping.cs
@@ -3,7 +3,6 @@ using MyRecipeBook.Communication.Enums;
 using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Requests;
 using MyRecipeBook.Communication.Response;
-using MyRecipeBook.Communication.Responses;
 using Sqids;
 
 namespace MyRecipeBook.Application.Services.AutoMapper
@@ -59,8 +58,13 @@ namespace MyRecipeBook.Application.Services.AutoMapper
         private void DomainToResponse()
         {
             CreateMap<Domain.Entities.User, ResponseUserProfileJson>();
+
             CreateMap<Domain.Entities.Recipe, ResponseRegisteredRecipeJson>()
                 .ForMember(dest => dest.Id, config => config.MapFrom(src => _idEncoder.Encode(src.Id)));
+
+            CreateMap<Domain.Entities.Recipe, ResponseShortRecipeJson>()
+                .ForMember(dest => dest.Id, config => config.MapFrom(src => _idEncoder.Encode(src.Id)))
+                .ForMember(dest => dest.AmountIngredients, config => config.MapFrom(src => src.Ingredients.Count));
         }
 
     }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/FilterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/FilterRecipeUseCase.cs
@@ -1,0 +1,60 @@
+﻿using AutoMapper;
+using MyRecipeBook.Communication.Request;
+using MyRecipeBook.Communication.Response;
+using MyRecipeBook.Domain.Extension;
+using MyRecipeBook.Domain.Repositories.Recipe;
+using MyRecipeBook.Domain.Services.LoggedUser;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.Filter
+{
+    public class FilterRecipeUseCase : IFilterRecipeUseCase
+    {
+        private readonly IMapper _mapper;
+        private readonly ILoggedUser _loggedUser;
+        private readonly IRecipeReadOnlyRepository _repository;
+
+        public FilterRecipeUseCase(IMapper mapper, ILoggedUser loggedUser, IRecipeReadOnlyRepository repository)
+        {
+            _mapper = mapper;
+            _loggedUser = loggedUser;
+            _repository = repository;
+        }
+
+        public async Task<ResponseRecipesJson> Execute(RequestFilterRecipeJson request)
+        {
+            Validate(request);
+
+            var loggedUser = await _loggedUser.User();
+
+            var filters = new Domain.Dtos.FilterRecipesDto
+            {
+                RecipeTitle_Ingredient = request.RecipeTitle_Ingredient,
+                CookingTimes = request.CookingTimes.Distinct().Select(c => (Domain.Enums.RecipeCookingTime)c).ToList(),
+                Difficulties = request.Difficulties.Distinct().Select(c => (Domain.Enums.RecipeDifficulty)c).ToList(),
+                DishTypes = request.DishTypes.Distinct().Select(c => (Domain.Enums.RecipeDishType)c).ToList(),
+            };
+
+            var recipes = await _repository.Filter(user: loggedUser, filters: filters);
+
+            return new ResponseRecipesJson
+            {
+                Recipes = _mapper.Map<List<ResponseShortRecipeJson>>(recipes)
+            };
+        }
+
+        private void Validate(RequestFilterRecipeJson request) 
+        {
+            var validator = new FilterRecipeValidator();
+
+            var result = validator.Validate(request);
+
+            if (result.IsValid.isFalse()) 
+            {
+                var errorMessages = result.Errors.Select(error => error.ErrorMessage).Distinct().ToList();
+
+                throw new ErrorOnValidationException(errorMessages);
+            }
+        }
+    }
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/FilterRecipeValidator.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/FilterRecipeValidator.cs
@@ -1,0 +1,16 @@
+﻿using FluentValidation;
+using MyRecipeBook.Communication.Request;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.Filter
+{
+    public class FilterRecipeValidator : AbstractValidator<RequestFilterRecipeJson>
+    {
+        public FilterRecipeValidator()
+        {
+            RuleForEach(r => r.CookingTimes).IsInEnum().WithMessage(ResourceMessageHelper.FieldNotSupported(fieldName: "CookingTime"));
+            RuleForEach(r => r.Difficulties).IsInEnum().WithMessage(ResourceMessageHelper.FieldNotSupported(fieldName: "Difficulties"));
+            RuleForEach(r => r.DishTypes).IsInEnum().WithMessage(ResourceMessageHelper.FieldNotSupported(fieldName: "DishTypes"));
+        }
+    }
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/IFilterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/IFilterRecipeUseCase.cs
@@ -1,0 +1,11 @@
+﻿using MyRecipeBook.Communication.Request;
+using MyRecipeBook.Communication.Response;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.Filter
+{
+    public interface IFilterRecipeUseCase
+    {
+        Task<ResponseRecipesJson> Execute(RequestFilterRecipeJson request);
+
+    }
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/IRegisterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/IRegisterRecipeUseCase.cs
@@ -1,5 +1,5 @@
 ﻿using MyRecipeBook.Communication.Request;
-using MyRecipeBook.Communication.Responses;
+using MyRecipeBook.Communication.Response;
 
 namespace MyRecipeBook.Application.UseCases.Recipe.Register
 {

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
@@ -1,6 +1,6 @@
 ﻿using AutoMapper;
 using MyRecipeBook.Communication.Request;
-using MyRecipeBook.Communication.Responses;
+using MyRecipeBook.Communication.Response;
 using MyRecipeBook.Domain.Repositories;
 using MyRecipeBook.Domain.Repositories.CookingTime;
 using MyRecipeBook.Domain.Repositories.Difficulty;

--- a/src/shared/MyRecipeBook.Communucation/Request/RequestFilterRecipeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Request/RequestFilterRecipeJson.cs
@@ -1,0 +1,12 @@
+﻿using MyRecipeBook.Communication.Enums;
+
+namespace MyRecipeBook.Communication.Request
+{
+    public class RequestFilterRecipeJson
+    {
+        public string? RecipeTitle_Ingredient { get; set; }
+        public IList<RecipeCookingTime> CookingTimes { get; set; } = [];
+        public IList<RecipeDifficulty> Difficulties { get; set; } = [];
+        public IList<RecipeDishType> DishTypes { get; set; } = [];
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseRecipesJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseRecipesJson.cs
@@ -1,0 +1,7 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseRecipesJson
+    {
+        public IList<ResponseShortRecipeJson> Recipes { get; set; } = [];
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseRegisteredRecipeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseRegisteredRecipeJson.cs
@@ -1,4 +1,4 @@
-﻿namespace MyRecipeBook.Communication.Responses
+﻿namespace MyRecipeBook.Communication.Response
 {
     public class ResponseRegisteredRecipeJson
     {

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseShortRecipeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseShortRecipeJson.cs
@@ -1,0 +1,9 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseShortRecipeJson
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Title {  get; set; } = string.Empty;
+        public int AmountIngredients { get; set; }
+    }
+}


### PR DESCRIPTION
- Add **POST `/recipes/filter`** action to `RecipeController`, returning `ResponseRecipesJson` (200) or 204 when no matches.
- Create `FilterRecipeUseCase`, `FilterRecipeValidator`, and `FilterRecipesDto` to orchestrate validation and domain filtering.
- Extend `RecipeRepository` with `Filter` query using EF-Core, eager loading ingredients and applying dynamic predicates.
- Introduce `IRecipeReadOnlyRepository` and register it alongside the existing write repository in DI layers (Infrastructure & Application).
- Add new communication models `RequestFilterRecipeJson`, `ResponseRecipesJson`, `ResponseShortRecipeJson`.
- Map `Recipe → ResponseShortRecipeJson` in AutoMapper, including encoded ID and ingredient count.
- Rename `MyRecipeBook.Communication.Responses` → `.Response` across affected files for naming consistency.