### PR TITLE
Parameterize DB creation & tidy code

### DIFF
--- a/src/backend/MyRecipeBook.Infrastructure/Migrations/DatabaseMigration.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Migrations/DatabaseMigration.cs
@@ -11,7 +11,7 @@ namespace MyRecipeBook.Infrastructure.Migrations
 
     public static class DatabaseMigration
     {
-        private static readonly Regex _schemaNameRegex = new(@"^[A-Za-z0-9_]+$", RegexOptions.Compiled);
+       
         public static void Migrate(string connectionString, IServiceProvider serviceProvider)
         {
             EnsureDatabaseCreate(connectionString);
@@ -24,10 +24,6 @@ namespace MyRecipeBook.Infrastructure.Migrations
 
             var databaseName = connectionStringBuilder.Database;
 
-            if (!_schemaNameRegex.IsMatch(databaseName))
-                throw new InvalidOperationException(
-                    $"Nome de schema inválido: {databaseName}");
-
             var quotedName = $"`{databaseName.Replace("`", "``")}`";
 
             connectionStringBuilder.Remove("Database");
@@ -36,11 +32,12 @@ namespace MyRecipeBook.Infrastructure.Migrations
 
             var parameters = new DynamicParameters();
             parameters.Add("name", databaseName);
+            parameters.Add("databaseName", databaseName);
 
             var records = dbConnection.Query("SELECT * FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = @name", parameters);
 
             if(!records.Any())
-                dbConnection.Execute($"CREATE DATABASE {quotedName}");
+                dbConnection.Execute($"CREATE DATABASE @databaseName", parameters);
             
         }
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/FilterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Filter/FilterRecipeUseCase.cs
@@ -43,7 +43,7 @@ namespace MyRecipeBook.Application.UseCases.Recipe.Filter
             };
         }
 
-        private void Validate(RequestFilterRecipeJson request) 
+        private static void Validate(RequestFilterRecipeJson request) 
         {
             var validator = new FilterRecipeValidator();
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
@@ -53,7 +53,7 @@ namespace MyRecipeBook.Application.UseCases.Recipe.Register
 
             var instructions = request.Instructions.OrderBy(i => i.Step).ToList();
             for (var i = 0; i < instructions.Count; i++)
-                instructions.ElementAt(i).Step = i + 1;
+                instructions[i].Step = i + 1;
 
             recipe.Instructions = _mapper.Map<IList<Domain.Entities.Instruction>>(instructions);
 


### PR DESCRIPTION
- Replace interpolated `CREATE DATABASE` with a parameterized command, adding `@databaseName` to `DynamicParameters`; drop the now-unnecessary `_schemaNameRegex`.
- Mark `FilterRecipeUseCase.Validate()` as `static` to reflect its pure validation role.
- Iterate recipe instructions with `instructions[i]` instead of `ElementAt(i)` to avoid LINQ overhead.