### PR TITLE
Refactor migration to use DbObjects constants

### DIFF
--- a/src/backend/MyRecipeBook.Infrastructure/Migrations/Versions/Version0000002.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Migrations/Versions/Version0000002.cs
@@ -1,30 +1,30 @@
 ﻿using FluentMigrator;
 using MyRecipeBook.Infrastructure.Persistence;
+using System.Data;
 
 namespace MyRecipeBook.Infrastructure.Migrations.Versions
 {
     [Migration(DatabaseVersions.TABLE_RECIPES, "Create table to save the recipes' information")]
     public class Version0000002 : VersionBase
     {
-
         public override void Up()
         {
             // Tabelas de referência
-            CreateReferenceTable(DbNames.Tables.CookingTime);
-            Insert.IntoTable(DbNames.Tables.CookingTime)
+            CreateReferenceTable(DbObjects.CookingTime.TableName);
+            Insert.IntoTable(DbObjects.CookingTime.TableName)
                 .Row(new { Description = "< 10 mins" })
                 .Row(new { Description = "10-30 mins" })
                 .Row(new { Description = "30-60 mins" })
                 .Row(new { Description = "> 60 mins" });
 
-            CreateReferenceTable(DbNames.Tables.Difficulty);
-            Insert.IntoTable(DbNames.Tables.Difficulty)
+            CreateReferenceTable(DbObjects.Difficulty.TableName);
+            Insert.IntoTable(DbObjects.Difficulty.TableName)
                 .Row(new { Description = "Low" })
                 .Row(new { Description = "Medium" })
                 .Row(new { Description = "High" });
 
-            CreateReferenceTable(DbNames.Tables.DishTypes);
-            Insert.IntoTable(DbNames.Tables.DishTypes)
+            CreateReferenceTable(DbObjects.DishTypes.TableName);
+            Insert.IntoTable(DbObjects.DishTypes.TableName)
                 .Row(new { Description = "Breakfast" })
                 .Row(new { Description = "Lunch" })
                 .Row(new { Description = "Appetizers" })
@@ -34,50 +34,50 @@ namespace MyRecipeBook.Infrastructure.Migrations.Versions
                 .Row(new { Description = "Drinks" });
 
             // Tabela principal
-            CreateTable(DbNames.Tables.Recipes)
-                .WithColumn("Title").AsString(200).NotNullable()
-                .WithColumn("CookingTimeId").AsInt32().Nullable()
-                    .ForeignKey("FK_Recipe_CookingTime_Id", "CookingTime", "Id")
-                .WithColumn("DifficultyId").AsInt32().Nullable()
-                    .ForeignKey("FK_Recipe_Difficulty_Id", "Difficulty", "Id")
-                .WithColumn("UserId").AsInt64().NotNullable()
-                    .ForeignKey("FK_Recipe_User_Id", "Users", "Id");
+            CreateTable(DbObjects.Recipes.TableName)
+                .WithColumn(DbObjects.Recipes.Title).AsString(200).NotNullable()
+                .WithColumn(DbObjects.Recipes.CookingTimeId).AsInt32().Nullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.Recipes.TableName, DbObjects.CookingTime.TableName), DbObjects.CookingTime.TableName, DbObjects.CookingTime.Id)
+                .WithColumn(DbObjects.Recipes.DifficultyId).AsInt32().Nullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.Recipes.TableName, DbObjects.Difficulty.TableName), DbObjects.Difficulty.TableName, DbObjects.Difficulty.Id)
+                .WithColumn(DbObjects.Recipes.UserId).AsInt64().NotNullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.Recipes.TableName, DbObjects.Users.TableName), DbObjects.Users.TableName, DbObjects.Users.Id);
 
             // Tabelas dependentes
-            CreateTable(DbNames.Tables.Ingredients)
-                .WithColumn("Item").AsString(100).NotNullable()
-                .WithColumn("RecipeId").AsInt64().NotNullable()
-                    .ForeignKey("FK_Ingredient_Recipe_Id", "Recipes", "Id")
-                        .OnDelete(System.Data.Rule.Cascade);
+            CreateTable(DbObjects.Ingredients.TableName)
+                .WithColumn(DbObjects.Ingredients.Item).AsString(100).NotNullable()
+                .WithColumn(DbObjects.Ingredients.RecipeId).AsInt64().NotNullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.Ingredients.TableName, DbObjects.Recipes.TableName), DbObjects.Recipes.TableName, DbObjects.Recipes.Id)
+                        .OnDelete(Rule.Cascade);
 
-            CreateTable(DbNames.Tables.Instructions)
-                .WithColumn("Step").AsInt32().NotNullable()
-                .WithColumn("Description").AsString(2000).NotNullable()
-                .WithColumn("RecipeId").AsInt64().NotNullable()
-                    .ForeignKey("FK_Instruction_Recipe_Id", "Recipes", "Id")
-                        .OnDelete(System.Data.Rule.Cascade);
+            CreateTable(DbObjects.Instructions.TableName)
+                .WithColumn(DbObjects.Instructions.Step).AsInt32().NotNullable()
+                .WithColumn(DbObjects.Instructions.Description).AsString(2000).NotNullable()
+                .WithColumn(DbObjects.Instructions.RecipeId).AsInt64().NotNullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.Instructions.TableName, DbObjects.Recipes.TableName), DbObjects.Recipes.TableName, DbObjects.Recipes.Id)
+                        .OnDelete(Rule.Cascade);
 
             // Tabela de ligação
-            CreateJunctionTable(DbNames.Tables.RecipesDishTypes)
-                .WithColumn("RecipeId").AsInt64().NotNullable()
-                    .ForeignKey("FK_RecipesDishTypes_Recipe_Id", "Recipes", "Id")
-                        .OnDelete(System.Data.Rule.Cascade)
-                .WithColumn("DishTypeId").AsInt32().NotNullable()
-                    .ForeignKey("FK_RecipesDishTypes_DishType_Id", "DishTypes", "Id");
+            CreateJunctionTable(DbObjects.RecipesDishTypes.TableName)
+                .WithColumn(DbObjects.RecipesDishTypes.RecipeId).AsInt64().NotNullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.RecipesDishTypes.TableName, DbObjects.Recipes.TableName), DbObjects.Recipes.TableName, DbObjects.Recipes.Id)
+                        .OnDelete(Rule.Cascade)
+                .WithColumn(DbObjects.RecipesDishTypes.DishTypeId).AsInt32().NotNullable()
+                    .ForeignKey(DbObjects.Naming.FK(DbObjects.RecipesDishTypes.TableName, DbObjects.DishTypes.TableName), DbObjects.DishTypes.TableName, DbObjects.DishTypes.Id);
 
             // Constraints e índices
-            Create.PrimaryKey("PK_RecipesDishTypes")
-                .OnTable("RecipesDishTypes")
-                .Columns("RecipeId", "DishTypeId");
+            Create.PrimaryKey(DbObjects.Naming.PK(DbObjects.RecipesDishTypes.TableName))
+                .OnTable(DbObjects.RecipesDishTypes.TableName)
+                .Columns(DbObjects.RecipesDishTypes.RecipeId, DbObjects.RecipesDishTypes.DishTypeId);
 
-            Create.UniqueConstraint("UC_Instructions_Recipe_Step")
-                .OnTable("Instructions")
-                .Columns("RecipeId", "Step");
+            Create.UniqueConstraint(DbObjects.Naming.UC(DbObjects.Instructions.TableName, DbObjects.Instructions.RecipeId, DbObjects.Instructions.Step))
+                .OnTable(DbObjects.Instructions.TableName)
+                .Columns(DbObjects.Instructions.RecipeId, DbObjects.Instructions.Step);
 
             // Índices para performance
-            Create.Index("IX_Recipes_UserId").OnTable(DbNames.Tables.Recipes).OnColumn("UserId");
-            Create.Index("IX_Ingredients_RecipeId").OnTable(DbNames.Tables.Ingredients).OnColumn("RecipeId");
-            Create.Index("IX_Instructions_RecipeId").OnTable(DbNames.Tables.Instructions).OnColumn("RecipeId");
+            Create.Index(DbObjects.Naming.IX(DbObjects.Recipes.TableName, DbObjects.Recipes.UserId)).OnTable(DbObjects.Recipes.TableName).OnColumn(DbObjects.Recipes.UserId);
+            Create.Index(DbObjects.Naming.IX(DbObjects.Ingredients.TableName, DbObjects.Ingredients.RecipeId)).OnTable(DbObjects.Ingredients.TableName).OnColumn(DbObjects.Ingredients.RecipeId);
+            Create.Index(DbObjects.Naming.IX(DbObjects.Instructions.TableName, DbObjects.Instructions.RecipeId)).OnTable(DbObjects.Instructions.TableName).OnColumn(DbObjects.Instructions.RecipeId);
         }
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/Persistence/Persistence.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Persistence/Persistence.cs
@@ -1,22 +1,80 @@
 ﻿namespace MyRecipeBook.Infrastructure.Persistence
 {
-    public static class DbNames
+
+    public static class DbObjects
     {
-        public static class Tables
+      
+        public static class Naming
         {
-            public const string Recipes = "Recipes";
-            public const string Ingredients = "Ingredients";
-            public const string Instructions = "Instructions";
-            public const string CookingTime = "CookingTime";
-            public const string Difficulty = "Difficulty";
-            public const string DishTypes = "DishTypes";
-            public const string RecipesDishTypes = "RecipesDishTypes";
-            public const string Users = "Users";
+          
+            public static string FK(string fromTable, string toTable) => $"FK_{fromTable}_{toTable}";
+
+        
+            public static string PK(string table) => $"PK_{table}";
+
+            
+            public static string IX(string table, params string[] columns) => $"IX_{table}_{string.Join("_", columns)}";
+
+            
+            public static string UC(string table, params string[] columns) => $"UC_{table}_{string.Join("_", columns)}";
         }
 
-        public static class Schemas
+        public static class Users
         {
-            public const string Default = ""; 
+            public const string TableName = "Users";
+            public const string Id = "Id";
+        }
+
+        public static class CookingTime
+        {
+            public const string TableName = "CookingTime";
+            public const string Id = "Id";
+        }
+
+        public static class Difficulty
+        {
+            public const string TableName = "Difficulty";
+            public const string Id = "Id";
+        }
+
+        public static class DishTypes
+        {
+            public const string TableName = "DishTypes";
+            public const string Id = "Id";
+        }
+
+        public static class Recipes
+        {
+            public const string TableName = "Recipes";
+            public const string Id = "Id";
+            public const string Title = "Title";
+            public const string UserId = "UserId";
+            public const string CookingTimeId = "CookingTimeId";
+            public const string DifficultyId = "DifficultyId";
+        }
+
+        public static class Ingredients
+        {
+            public const string TableName = "Ingredients";
+            public const string Id = "Id";
+            public const string Item = "Item";
+            public const string RecipeId = "RecipeId";
+        }
+
+        public static class Instructions
+        {
+            public const string TableName = "Instructions";
+            public const string Id = "Id";
+            public const string Description = "Description";
+            public const string RecipeId = "RecipeId";
+            public const string Step = "Step";
+        }
+
+        public static class RecipesDishTypes
+        {
+            public const string TableName = "RecipesDishTypes";
+            public const string RecipeId = "RecipeId";
+            public const string DishTypeId = "DishTypeId";
         }
     }
 }


### PR DESCRIPTION
- Replaces hardcoded table/column/constraint names in `Version0000002` with centralized definitions from `DbObjects`.
- Adds structured classes for each domain table and common naming helpers (FK, PK, IX, UC) to build consistent identifiers.
- Improves readability and refactor-safety across future migrations.