### PR TITLE
Feature/add filter recipe tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build, Test and Analyze
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [ready_for_review]
     branches:
       - develop
   push:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 name: Build, Test and Analyze
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, synchronize]
     branches:
       - develop
   push:

--- a/CommonTestUtilities/Entities/RecipeBuilder.cs
+++ b/CommonTestUtilities/Entities/RecipeBuilder.cs
@@ -1,0 +1,57 @@
+﻿using Bogus;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Enums;
+
+
+namespace CommonTestUtilities.Entities
+{
+    public class RecipeBuilder
+    {
+        public static IList<Recipe> Collection(User user, uint count = 2)
+        {
+            var list = new List<Recipe>();
+
+            if (count == 0)
+                count = 1;
+
+            var recipeId = 1;
+
+            for (int i = 0; i < count; i++)
+            {
+                var fakeRecipe = Build(user);
+                fakeRecipe.Id = recipeId++;
+
+                list.Add(fakeRecipe);
+            }
+
+            return list;
+        }
+
+        public static Recipe Build(User user)
+        {
+            return new Faker<Recipe>()
+                .RuleFor(r => r.Id, () => 1)
+                .RuleFor(r => r.Title, (f) => f.Lorem.Word())
+                .RuleFor(r => r.CookingTimeId, (f) => f.PickRandom<RecipeCookingTime>())
+                .RuleFor(r => r.DifficultyId, (f) => f.PickRandom<RecipeDifficulty>())
+                .RuleFor(r => r.Ingredients, (f) => f.Make(1, () => new Ingredient
+                {
+                    Id = 1,
+                    Item = f.Commerce.ProductName()
+                }))
+                .RuleFor(r => r.Instructions, (f) => f.Make(1, () => new Instruction
+                {
+                    Id = 1,
+                    Step = 1,
+                    Description = f.Lorem.Paragraph()
+                }))
+                .RuleFor(u => u.RecipeDishTypes, (f) => f.Make(1, () => new MyRecipeBook.Domain.Entities.RecipeDishType
+                {
+                    RecipeId = 1,
+                    DishTypeId = f.PickRandom<MyRecipeBook.Domain.Enums.RecipeDishType>()
+                }))
+                .RuleFor(r => r.UserId, _ => user.Id);
+
+        }
+    }
+}

--- a/CommonTestUtilities/Repositories/RecipeReadOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/RecipeReadOnlyRepositoryBuilder.cs
@@ -1,0 +1,23 @@
+﻿using Moq;
+using MyRecipeBook.Domain.Dtos;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Repositories.Recipe;
+
+namespace CommonTestUtilities.Repositories
+{
+    public class RecipeReadOnlyRepositoryBuilder
+    {
+        private readonly Mock<IRecipeReadOnlyRepository> _repository;
+
+        public RecipeReadOnlyRepositoryBuilder() => _repository = new Mock<IRecipeReadOnlyRepository>();
+
+        public RecipeReadOnlyRepositoryBuilder Filter(User user, IList<Recipe> recipes)
+        {
+            _repository.Setup(repository => repository.Filter(user, It.IsAny<FilterRecipesDto>())).ReturnsAsync(recipes);
+
+            return this;
+        }
+
+        public IRecipeReadOnlyRepository Build() => _repository.Object;
+    }
+}

--- a/CommonTestUtilities/Requests/RequestFilterRecipeJsonBuilder.cs
+++ b/CommonTestUtilities/Requests/RequestFilterRecipeJsonBuilder.cs
@@ -1,0 +1,28 @@
+﻿using Bogus;
+using MyRecipeBook.Communication.Enums;
+using MyRecipeBook.Communication.Request;
+
+
+namespace CommonTestUtilities.Requests
+{
+    public class RequestFilterRecipeJsonBuilder
+    {
+
+        public static RequestFilterRecipeJson Build()
+        {
+            return new Faker<RequestFilterRecipeJson>()
+                 .RuleFor(r => r.RecipeTitle_Ingredient, f => f.Lorem.Word())
+                 .RuleFor(r => r.CookingTimes, f => f.Random.EnumValues<RecipeCookingTime>().Take(TakeNumber<RecipeCookingTime>()).ToList())
+                 .RuleFor(r => r.Difficulties, f => f.Random.EnumValues<RecipeDifficulty>().Take(TakeNumber<RecipeDifficulty>()).ToList())
+                 .RuleFor(r => r.DishTypes, f => f.Random.EnumValues<RecipeDishType>().Take(TakeNumber<RecipeDishType>()).ToList());
+        }
+
+        protected static int TakeNumber<TEnum>() where TEnum : Enum
+        {
+            var total = Enum.GetValues(typeof(TEnum)).Length;
+            var random = new Random();
+            return random.Next(1, total + 1);
+        }
+
+    }
+}

--- a/tests/UseCases.Test/Recipe/Filter/FilterRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Filter/FilterRecipeUseCaseTest.cs
@@ -1,0 +1,69 @@
+﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.LoggedUser;
+using CommonTestUtilities.Mapper;
+using CommonTestUtilities.Repositories;
+using CommonTestUtilities.Requests;
+using MyRecipeBook.Application.UseCases.Recipe.Filter;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+using Shouldly;
+
+namespace UseCases.Test.Recipe.Filter
+{
+    public class FilterRecipeUseCaseTest
+    {
+        [Fact]
+        public async Task Success()
+        {
+            (var user, _) = UserBuilder.Build();
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+
+            var recipes = RecipeBuilder.Collection(user);
+
+            var useCase = CreateUseCase(user, recipes);
+
+            var result = await useCase.Execute(request);
+
+            result.ShouldNotBeNull();
+            result.Recipes.ShouldNotBeNull();
+            result.Recipes.ShouldNotBeEmpty();
+            result.Recipes.Count.ShouldBe(recipes.Count);
+
+        }
+
+        [Fact]
+        public async Task Error_CookingTime_Invalid()
+        {
+            (var user, _) = UserBuilder.Build();
+
+            var recipes = RecipeBuilder.Collection(user);
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+            request.CookingTimes.Add((MyRecipeBook.Communication.Enums.RecipeCookingTime)1000);
+
+            var useCase = CreateUseCase(user, recipes);
+
+            Func<Task> act = async () => { await useCase.Execute(request); };
+
+            var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
+            ex.ShouldSatisfyAllConditions(
+                () => ex.ErrorMessages.Count.ShouldBe(1),
+                () => ex.ErrorMessages.ShouldContain(ResourceMessageHelper.FieldNotSupported("CookingTime"))
+            );
+
+        }
+
+
+        private static FilterRecipeUseCase CreateUseCase(
+            MyRecipeBook.Domain.Entities.User user,
+            IList<MyRecipeBook.Domain.Entities.Recipe> recipes
+            )
+        {
+            var mapper = MapperBuilder.Build();
+            var loggedUser = LoggedUserBuilder.Build(user);
+            var repository = new RecipeReadOnlyRepositoryBuilder().Filter(user, recipes).Build();
+
+            return new FilterRecipeUseCase(mapper, loggedUser, repository);
+        }
+    }
+}

--- a/tests/Validators.Test/Recipe/Filter/FilterRecipeValidatorTest.cs
+++ b/tests/Validators.Test/Recipe/Filter/FilterRecipeValidatorTest.cs
@@ -1,0 +1,68 @@
+﻿using CommonTestUtilities.Requests;
+using MyRecipeBook.Application.UseCases.Recipe.Filter;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+using Shouldly;
+
+namespace Validators.Test.Recipe.Filter
+{
+    public class FilterRecipeValidatorTest
+    {
+        [Fact]
+        public void Success()
+        {
+            var validator = new FilterRecipeValidator();
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+
+            var result = validator.Validate(request);
+
+            result.IsValid.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void Error_Invalid_Cooking_Time()
+        {
+            var validator = new FilterRecipeValidator();
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+            request.CookingTimes.Add((MyRecipeBook.Communication.Enums.RecipeCookingTime)1000);
+
+            var result = validator.Validate(request);
+
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldHaveSingleItem(ResourceMessageHelper.FieldNotSupported(fieldName: "CookingTime"));
+
+        }
+
+        [Fact]
+        public void Error_Invalid_Difficulties()
+        {
+            var validator = new FilterRecipeValidator();
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+            request.Difficulties.Add((MyRecipeBook.Communication.Enums.RecipeDifficulty)1000);
+
+            var result = validator.Validate(request);
+
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldHaveSingleItem(ResourceMessageHelper.FieldNotSupported(fieldName: "Difficulties"));
+
+        }
+
+        [Fact]
+        public void Error_Invalid_DishTypes()
+        {
+            var validator = new FilterRecipeValidator();
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+            request.DishTypes.Add((MyRecipeBook.Communication.Enums.RecipeDishType)1000);
+
+            var result = validator.Validate(request);
+
+            result.IsValid.ShouldBeFalse();
+            result.Errors.ShouldHaveSingleItem(ResourceMessageHelper.FieldNotSupported(fieldName: "DishTypes"));
+
+        }
+
+    }
+}

--- a/tests/WebApi.test/CustomWebApplicationFactory.cs
+++ b/tests/WebApi.test/CustomWebApplicationFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using MyRecipeBook.Domain.Enums;
 using MyRecipeBook.Infrastructure.DataAccess;
 
 namespace WebApi.test
@@ -11,6 +12,7 @@ namespace WebApi.test
     {
 
         private MyRecipeBook.Domain.Entities.User _user = default!;
+        private MyRecipeBook.Domain.Entities.Recipe _recipe = default!;
         private string _password = string.Empty;
 
         protected override void ConfigureWebHost(IWebHostBuilder builder)
@@ -47,11 +49,18 @@ namespace WebApi.test
         public string GetName() => _user.Name;
         public Guid GetUserIdentifier() => _user.UserIdentifier;
 
+        public string GetRecipeTitle() => _recipe.Title;
+        public RecipeDifficulty? GetDifficulty() => _recipe.DifficultyId;
+        public RecipeCookingTime? GetRecipeCookingTime() => _recipe.CookingTimeId;
+        public IList<RecipeDishType>? GetRecipeDishType() => _recipe.RecipeDishTypes.Select(rdt => rdt.DishTypeId).ToList();
+
         private void StartDatabase(MyRecipeBookDbContext dbContext)
         {
             (_user, _password) = UserBuilder.Build();
+            _recipe = RecipeBuilder.Build(user: _user);
 
             dbContext.Users.Add(_user);
+            dbContext.Recipes.Add(_recipe);
 
             dbContext.CookingTime.AddRange(
                 new MyRecipeBook.Domain.Entities.CookingTime { Id = MyRecipeBook.Domain.Enums.RecipeCookingTime.Less_10_Minutes, Description = "< 10 mins" },

--- a/tests/WebApi.test/Recipe/Filter/FilterRecipeInvalidTokenTest.cs
+++ b/tests/WebApi.test/Recipe/Filter/FilterRecipeInvalidTokenTest.cs
@@ -1,0 +1,51 @@
+﻿using CommonTestUtilities.Requests;
+using CommonTestUtilities.Tokens;
+using Shouldly;
+using System.Net;
+
+
+namespace WebApi.test.Recipe.Filter
+{
+    public class FilterRecipeInvalidTokenTest : MyRecipeBookClassFixture
+    {
+        private const string METHOD = "recipe/filter";
+        private const string INVALID_TOKEN = "123";
+
+        public FilterRecipeInvalidTokenTest(CustomWebApplicationFactory factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task Error_Invalid_Token()
+        {
+            var request = RequestFilterRecipeJsonBuilder.Build();
+
+            var response = await DoPost(method: METHOD, request: request, token: INVALID_TOKEN);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task Error_Without_Token()
+        {
+            var request = RequestFilterRecipeJsonBuilder.Build();
+
+            var response = await DoPost(method: METHOD, request: request, token: string.Empty);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task Error_Token_With_User_NotFound()
+        {
+            var request = RequestFilterRecipeJsonBuilder.Build();
+
+            var token = JwtTokensGeneratorBuilder.Build().Generate(Guid.NewGuid());
+
+            var response = await DoPost(method: METHOD, request: request, token: token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+    }
+}

--- a/tests/WebApi.test/Recipe/Filter/FilterRecipeTest.cs
+++ b/tests/WebApi.test/Recipe/Filter/FilterRecipeTest.cs
@@ -1,0 +1,111 @@
+﻿using CommonTestUtilities.Requests;
+using CommonTestUtilities.Tokens;
+using MyRecipeBook.Communication.Request;
+using MyRecipeBook.Domain.Enums;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+using WebApi.test.InlineData;
+
+
+namespace WebApi.test.Recipe.Filter
+{
+    public class FilterRecipeTest : MyRecipeBookClassFixture
+    {
+        private const string METHOD = "recipe/filter";
+        private const string INVALID_TOKEN = "123";
+
+        private readonly Guid _userIdentifier;
+
+        private string _recipeTitle;
+        private RecipeDifficulty? _recipeDifficulty;
+        private RecipeCookingTime? _recipeCookingTime;
+        private IList<RecipeDishType>? _recipeDishTypes;
+
+        public FilterRecipeTest(CustomWebApplicationFactory factory) : base(factory)
+        {
+            _userIdentifier = factory.GetUserIdentifier();
+
+            _recipeTitle = factory.GetRecipeTitle();
+            _recipeCookingTime = factory.GetRecipeCookingTime();
+            _recipeDifficulty = factory.GetDifficulty();
+            _recipeDishTypes = factory.GetRecipeDishType();
+        }
+
+        [Fact]
+        public async Task Success()
+        {
+            IList<MyRecipeBook.Communication.Enums.RecipeCookingTime> cookingTimes = [(MyRecipeBook.Communication.Enums.RecipeCookingTime)_recipeCookingTime!];
+            IList<MyRecipeBook.Communication.Enums.RecipeDifficulty> difficulties = [(MyRecipeBook.Communication.Enums.RecipeDifficulty)_recipeDifficulty!];
+            IList<MyRecipeBook.Communication.Enums.RecipeDishType> dishTypes = _recipeDishTypes!.Select(dishType => (MyRecipeBook.Communication.Enums.RecipeDishType)dishType).ToList();
+
+            var request = new RequestFilterRecipeJson
+            {
+                CookingTimes = cookingTimes,
+                Difficulties = difficulties,
+                DishTypes = dishTypes,
+                RecipeTitle_Ingredient = _recipeTitle,
+            };
+
+            var token = JwtTokensGeneratorBuilder.Build().Generate(_userIdentifier);
+
+            var response = await DoPost(method: METHOD, request: request, token: token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            await using var responseBody = await response.Content.ReadAsStreamAsync();
+
+            var responseData = await JsonDocument.ParseAsync(responseBody);
+
+            responseData.RootElement.GetProperty("recipes").EnumerateArray().ShouldNotBeEmpty();
+
+
+
+        }
+
+        [Fact]
+        public async Task Success_NoContent()
+        {
+            var recipeTitleOrIngredientNotExist = "recipeDontExists";
+
+            var request = RequestFilterRecipeJsonBuilder.Build();
+            request.RecipeTitle_Ingredient = recipeTitleOrIngredientNotExist;
+
+            var token = JwtTokensGeneratorBuilder.Build().Generate(_userIdentifier);
+
+            var response = await DoPost(method: METHOD, request: request, token: token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
+
+        }
+
+        [Theory]
+        [ClassData(typeof(CultureInlineDataTest))]
+        public async Task Error_CookingTime_Invalid(string culture)
+        {
+            var request = RequestFilterRecipeJsonBuilder.Build();
+            request.CookingTimes.Add((MyRecipeBook.Communication.Enums.RecipeCookingTime)100);
+
+            var token = JwtTokensGeneratorBuilder.Build().Generate(_userIdentifier);
+
+            var response = await DoPost(method: METHOD, request: request, token: token, culture: culture);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
+
+            await using var responseBody = await response.Content.ReadAsStreamAsync();
+
+            var responseData = await JsonDocument.ParseAsync(responseBody);
+
+            var errors = responseData.RootElement.GetProperty("errors").EnumerateArray();
+
+            var expectedMessage = ResourceMessageHelper.FieldNotSupported(fieldName: "CookingTime");
+
+            errors.ShouldSatisfyAllConditions(
+               e => e.ShouldHaveSingleItem(),
+               e => e.Single().GetString()!.Equals(expectedMessage)
+           );
+        }
+
+    }
+}


### PR DESCRIPTION
Add tests and utilities for filtering recipes

- Introduced `RecipeBuilder`, `RequestFilterRecipeJsonBuilder`, and repository mocks for test data generation.
- Implemented unit tests for `FilterRecipeUseCase` validating success and validation error scenarios.
- Added `FilterRecipeValidatorTest` to verify validator behavior against various input combinations.
- Extended `CustomWebApplicationFactory` to seed test data, supporting WebApi integration tests.
- Developed WebApi tests covering token authentication, success cases, no-content, and validation errors.
