### PR TITLE
Add recipe “get by id” flow and exception refactor

### DIFF
--- a/CommonTestUtilities/IdEncryption/IdEncripterBuilder.cs
+++ b/CommonTestUtilities/IdEncryption/IdEncripterBuilder.cs
@@ -8,7 +8,7 @@ public class IdEncripterBuilder
         return new SqidsEncoder<long>(new()
         {
             MinLength = 3,
-            Alphabet = "LbNCQzTuDfKj1m6q09dEox7XRPiJIhMV4tlBFSAypUH823rwencG5kvagOZYsW"
+            Alphabet = "rOvmjkATPy2xsp8WbouJKBZw9Q1ftVNCYSgDi5GqH4hlacIU7FnEeMdRzX63L0"
         });
     }
 }

--- a/CommonTestUtilities/Repositories/RecipeReadOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/RecipeReadOnlyRepositoryBuilder.cs
@@ -17,6 +17,13 @@ namespace CommonTestUtilities.Repositories
 
             return this;
         }
+        public RecipeReadOnlyRepositoryBuilder GetById(User user, Recipe? recipe)
+        {
+            if (recipe is not null)
+                _repository.Setup(repository => repository.GetById(user, recipe.Id)).ReturnsAsync(recipe);
+
+            return this;
+        }
 
         public IRecipeReadOnlyRepository Build() => _repository.Object;
     }

--- a/src/backend/MyRecipeBook.API/Binders/MyRecipeBookIdBinder.cs
+++ b/src/backend/MyRecipeBook.API/Binders/MyRecipeBookIdBinder.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Sqids;
+
+namespace MyRecipeBook.API.Binders
+{
+    public class MyRecipeBookIdBinder : IModelBinder
+    {
+
+        private readonly SqidsEncoder<long> _idEncoder;
+
+        public MyRecipeBookIdBinder(SqidsEncoder<long> idEncoder) => _idEncoder = idEncoder;
+
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            var modelName = bindingContext.ModelName;
+
+            var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+
+            if (valueProviderResult == ValueProviderResult.None)
+                return Task.CompletedTask;
+
+            bindingContext.ModelState.SetModelValue(modelName, valueProviderResult);
+
+            var value = valueProviderResult.FirstValue;
+
+            if (string.IsNullOrWhiteSpace(value))
+                return Task.CompletedTask;
+
+            var id = _idEncoder.Decode(value).Single();
+
+            bindingContext.Result = ModelBindingResult.Success(id);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using MyRecipeBook.API.Attributes;
+using MyRecipeBook.API.Binders;
 using MyRecipeBook.Application.UseCases.Recipe.Filter;
+using MyRecipeBook.Application.UseCases.Recipe.GetById;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
 using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Response;
@@ -11,6 +13,20 @@ namespace MyRecipeBook.API.Controllers
     [AuthenticatedUser]
     public class RecipeController : MyRecipeBookBaseController
     {
+        [HttpGet]
+        [Route("{id}")]
+        [ProducesResponseType(typeof(ResponseRecipeJson), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> GetById(
+            [FromServices] IGetRecipeByIdUseCase useCase,
+            [FromRoute][ModelBinder(typeof(MyRecipeBookIdBinder))] long id
+       )
+        {
+            var response = await useCase.Execute(id);
+
+            return Ok(response);
+        }
+
         [HttpPost]
         [ProducesResponseType(typeof(ResponseRegisteredRecipeJson), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
@@ -24,6 +40,7 @@ namespace MyRecipeBook.API.Controllers
             return Created(string.Empty, response);
         }
 
+
         [HttpPost("filter")]
         [ProducesResponseType(typeof(ResponseRecipesJson), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
@@ -34,7 +51,7 @@ namespace MyRecipeBook.API.Controllers
         {
             var response = await useCase.Execute(request);
 
-            if (response.Recipes.Any()) 
+            if (response.Recipes.Any())
                 return Ok(response);
 
             return NoContent();

--- a/src/backend/MyRecipeBook.API/Filters/AuthenticatedUserFilter.cs
+++ b/src/backend/MyRecipeBook.API/Filters/AuthenticatedUserFilter.cs
@@ -30,7 +30,7 @@ namespace MyRecipeBook.API.Filters
 
                 var exist = await _repository.ExistActiveUserWithIdentifier(userIdentifier);
 
-                if (exist.isFalse()) throw new MyRecipeBookException(ResourceMessagesException.USER_WITHOUT_PERMISSION_ACCESS_RESOURCE);
+                if (exist.isFalse()) throw new UnauthorizedAccessException(ResourceMessagesException.USER_WITHOUT_PERMISSION_ACCESS_RESOURCE);
             }
             catch (SecurityTokenExpiredException)
             {
@@ -54,7 +54,7 @@ namespace MyRecipeBook.API.Filters
         {
             var authentication = context.HttpContext.Request.Headers.Authorization.ToString();
 
-            if (string.IsNullOrWhiteSpace(authentication)) throw new MyRecipeBookException(ResourceMessagesException.NO_TOKEN);
+            if (string.IsNullOrWhiteSpace(authentication)) throw new UnauthorizedAccessException(ResourceMessagesException.NO_TOKEN);
 
             return authentication["Bearer ".Length..].Trim();
         }

--- a/src/backend/MyRecipeBook.API/Filters/ExceptionFilter.cs
+++ b/src/backend/MyRecipeBook.API/Filters/ExceptionFilter.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using MyRecipeBook.Communication.Response;
 using MyRecipeBook.Exceptions;
 using MyRecipeBook.Exceptions.ExceptionsBase;
-using System.Net;
 
 namespace MyRecipeBook.API.Filters
 {
@@ -11,32 +10,41 @@ namespace MyRecipeBook.API.Filters
     {
         public void OnException(ExceptionContext context)
         {
-            if(context.Exception is MyRecipeBookException) 
-                HandleProjectException(context);
-            else 
+            if (context.Exception is MyRecipeBookException myRecipeBookException)
+                HandleProjectException(myRecipeBookException, context);
+            else
                 ThrowUnknowException(context);
-           
+
         }
 
-        private static void HandleProjectException(ExceptionContext context)
+        private static void HandleProjectException(MyRecipeBookException myRecipeBookException, ExceptionContext context)
         {
-            if(context.Exception is InvalidLoginException)
-            {
-                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-                context.Result = new UnauthorizedObjectResult(new ResponseErrorJson(context.Exception.Message));
-                return;
-            }
+            context.HttpContext.Response.StatusCode = (int)myRecipeBookException.GetStatusCode();
+            context.Result = new ObjectResult(new ResponseErrorJson(myRecipeBookException.GetErrorMessages()));
 
-            if(context.Exception is ErrorOnValidationException exception)
-            {
-                context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
-                context.Result = new BadRequestObjectResult(new ResponseErrorJson(exception.ErrorMessages));
-            }
+            //if (context.Exception is InvalidLoginException)
+            //{
+            //    context.HttpContext.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
+            //    context.Result = new UnauthorizedObjectResult(new ResponseErrorJson(context.Exception.Message));
+            //    return;
+            //}
+
+            //if (context.Exception is ErrorOnValidationException exception)
+            //{
+            //    context.HttpContext.Response.StatusCode = (int)HttpStatusCode.BadRequest;
+            //    context.Result = new BadRequestObjectResult(new ResponseErrorJson(exception.ErrorMessages));
+            //}
+
+            //if (context.Exception is NotFoundException)
+            //{
+            //    context.HttpContext.Response.StatusCode = StatusCodes.Status404NotFound;
+            //    context.Result = new NotFoundObjectResult(new ResponseErrorJson(context.Exception.Message));
+            //}
         }
 
         private static void ThrowUnknowException(ExceptionContext context)
         {
-            context.HttpContext.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
+            context.HttpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
             context.Result = new ObjectResult(new ResponseErrorJson(ResourceMessagesException.UNKNOWN_ERROR));
         }
     }

--- a/src/backend/MyRecipeBook.API/Filters/IdsFilter.cs
+++ b/src/backend/MyRecipeBook.API/Filters/IdsFilter.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.OpenApi.Models;
+using MyRecipeBook.API.Binders;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MyRecipeBook.API.Filters
+{
+    internal sealed class IdsFilter : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var encryptedIds = context
+                .ApiDescription
+                .ParameterDescriptions
+                .Where(x => x.ModelMetadata.BinderType == typeof(MyRecipeBookIdBinder))
+                .ToDictionary(d => d.Name, d => d);
+
+            foreach (var parameter in operation.Parameters) 
+            {
+                if(encryptedIds.TryGetValue(parameter.Name, out var apiParameter))
+                {
+                    parameter.Schema.Format = string.Empty;
+                    parameter.Schema.Type = "string";
+                }
+                
+            }
+
+            foreach (var schema in context.SchemaRepository.Schemas.Values) 
+            {
+                foreach (var property in schema.Properties)
+                {
+                    if (encryptedIds.TryGetValue(property.Key, out var apiParameter))
+                    {
+                        property.Value.Format = string.Empty;
+                        property.Value.Type = "string";
+                    }
+                }
+                
+            }
+        }
+    }
+}

--- a/src/backend/MyRecipeBook.API/Filters/ScalarIdsDocumentTransformer.cs
+++ b/src/backend/MyRecipeBook.API/Filters/ScalarIdsDocumentTransformer.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+using MyRecipeBook.API.Binders;
+using Microsoft.AspNetCore.Mvc.ApiExplorer;
+
+namespace MyRecipeBook.API.Filters
+{
+    internal sealed class ScalarIdsDocumentTransformer : IOpenApiDocumentTransformer
+    {
+        public Task TransformAsync(
+            OpenApiDocument document,
+            OpenApiDocumentTransformerContext context,
+            CancellationToken cancellationToken)
+        {
+           
+            foreach (var path in document.Paths)
+            {
+                foreach (var operation in path.Value.Operations)
+                {
+                    if (operation.Value.Parameters != null)
+                    {
+                        foreach (var parameter in operation.Value.Parameters)
+                        {
+                            
+                            if (parameter.Name == "id" && parameter.Schema?.Type == "integer")
+                            {
+                                parameter.Schema.Type = "string";
+                                parameter.Schema.Format = null;
+                                parameter.Description = "Encrypted ID (string)";
+                            }
+                        }
+                    }
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -26,16 +26,18 @@ builder.Services.AddSwaggerGen(c =>
 {
     c.SupportNonNullableReferenceTypes();
     c.UseAllOfToExtendReferenceSchemas();
+
+    c.OperationFilter<IdsFilter>();
+
     c.AddSecurityDefinition(_bearer, new OpenApiSecurityScheme()
     {
         Name = "Authorization",
-        Type = SecuritySchemeType.ApiKey,
-        Scheme = _bearer,
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
         BearerFormat = "JWT",
         In = ParameterLocation.Header,
-        Description = "JWT Authorization header using the Bearer scheme." +
-        "Enter 'Bearer' [space] and then your token in the text input below." +
-        "Example: 'Bearer 12345abcdef'",
+        Description = "Enter your JWT token in the text input below." +
+        "Example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'",
 
     });
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
@@ -48,7 +50,7 @@ builder.Services.AddSwaggerGen(c =>
                                   Type = ReferenceType.SecurityScheme,
                                   Id = _bearer
                               },
-                              Scheme = "oauth2",
+                              Scheme = "bearer",
                               Name = _bearer,
                               In = ParameterLocation.Header
                           },
@@ -70,6 +72,7 @@ builder.Services.AddRouting(options => options.LowercaseUrls = true);
 builder.Services.AddOpenApi(options =>
 {
     options.AddDocumentTransformer<BearerSecuritySchemeTransformer>();
+    options.AddDocumentTransformer<ScalarIdsDocumentTransformer>();
 });
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)

--- a/src/backend/MyRecipeBook.Domain/Entities/Recipe.cs
+++ b/src/backend/MyRecipeBook.Domain/Entities/Recipe.cs
@@ -7,7 +7,9 @@ namespace MyRecipeBook.Domain.Entities
     {
         public string Title { get; set; } = string.Empty;
         public Enums.RecipeCookingTime? CookingTimeId { get; set; }
+        public CookingTime CookingTime { get; set; } = null!;
         public Enums.RecipeDifficulty? DifficultyId { get; set; }
+        public Difficulty Difficulty { get; set; } = null!;
         public IList<Ingredient> Ingredients { get; set; } = [];
         public IList<Instruction> Instructions { get; set; } = [];
         public IList<RecipeDishType> RecipeDishTypes { get; set; } = [];

--- a/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
@@ -5,5 +5,6 @@ namespace MyRecipeBook.Domain.Repositories.Recipe
     public interface IRecipeReadOnlyRepository
     {
         Task<IList<Entities.Recipe>> Filter(Entities.User user, FilterRecipesDto filters);
+        Task<Entities.Recipe?> GetById(long user, long recipeId);
     }
 }

--- a/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
@@ -5,6 +5,6 @@ namespace MyRecipeBook.Domain.Repositories.Recipe
     public interface IRecipeReadOnlyRepository
     {
         Task<IList<Entities.Recipe>> Filter(Entities.User user, FilterRecipesDto filters);
-        Task<Entities.Recipe?> GetById(long user, long recipeId);
+        Task<Entities.Recipe?> GetById(Entities.User user, long recipeId);
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
@@ -16,11 +16,11 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 
         public async Task<IList<Recipe>> Filter(User user, FilterRecipesDto filters)
         {
-           var query = _dbContext
-                .Recipes
-                .AsNoTracking()
-                .Include(recipe => recipe.Ingredients)
-                .Where(recipe => recipe.Active && recipe.UserId == user.Id);
+            var query = _dbContext
+                 .Recipes
+                 .AsNoTracking()
+                 .Include(recipe => recipe.Ingredients)
+                 .Where(recipe => recipe.Active && recipe.UserId == user.Id);
 
             if (filters.Difficulties.Any())
             {
@@ -39,11 +39,26 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 
             if (filters.RecipeTitle_Ingredient.NotEmpty())
             {
-                query = query.Where(recipe => recipe.Title.Contains(filters.RecipeTitle_Ingredient) 
+                query = query.Where(recipe => recipe.Title.Contains(filters.RecipeTitle_Ingredient)
                 || recipe.Ingredients.Any(ingredient => ingredient.Item.Contains(filters.RecipeTitle_Ingredient)));
             }
 
             return await query.ToListAsync();
+        }
+
+        public async Task<Recipe?> GetById(long userId, long recipeId)
+        {
+            return await _dbContext.Recipes
+                .AsNoTracking()
+                .Include(r => r.CookingTime)
+                .Include(r => r.Difficulty)
+                .Include(r => r.RecipeDishTypes)
+                    .ThenInclude(rd => rd.DishType)
+                .Include(r => r.Ingredients)
+                .Include(r => r.Instructions)
+                .FirstOrDefaultAsync(r => r.Id == recipeId &&
+                                          r.UserId == userId &&
+                                          r.Active);
         }
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
@@ -46,7 +46,7 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
             return await query.ToListAsync();
         }
 
-        public async Task<Recipe?> GetById(long userId, long recipeId)
+        public async Task<Recipe?> GetById(User user, long recipeId)
         {
             return await _dbContext.Recipes
                 .AsNoTracking()
@@ -57,7 +57,7 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
                 .Include(r => r.Ingredients)
                 .Include(r => r.Instructions)
                 .FirstOrDefaultAsync(r => r.Id == recipeId &&
-                                          r.UserId == userId &&
+                                          r.UserId == user.Id &&
                                           r.Active);
         }
     }

--- a/src/backend/MyRecipeBook.Infrastructure/Migrations/DatabaseVersions.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Migrations/DatabaseVersions.cs
@@ -4,5 +4,6 @@
     {
         public const int TABLE_USER = 1;
         public const int TABLE_RECIPES = 2;
+        public const int SEED_ADMIN_DATA = 3;
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/Migrations/Versions/Version0000003.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Migrations/Versions/Version0000003.cs
@@ -1,0 +1,389 @@
+﻿using FluentMigrator;
+using Microsoft.Extensions.Configuration;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Enums;
+using MyRecipeBook.Infrastructure.Security.Cryptography;
+using System.Data;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MyRecipeBook.Infrastructure.Migrations.Versions;
+
+[Migration(DatabaseVersions.SEED_ADMIN_DATA, "Insert admin user and sample recipes")]
+public class Version0000003 : VersionBase
+{
+    private readonly IConfiguration _configuration;
+    public Version0000003(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public override void Up()
+    {
+        var adminUserIdentifier = Guid.NewGuid();
+        var additionalKey = _configuration["Settings:Password:AdditionalKey"]
+                            ?? throw new InvalidOperationException("Settings:Password:AdditionalKey configuration not found");
+
+        var EncryptPassword = new Sha512Encripter(additionalKey);                            
+        var adminPassword = EncryptPassword.Encrypt("12345678");
+
+        var now = DateTime.UtcNow;
+
+        Insert.IntoTable(TableName<User>())
+            .Row(new
+            {
+                Name = "Administrator",
+                Email = "admin@admin.com",
+                Password = adminPassword,
+                UserIdentifier = adminUserIdentifier,
+                CreatedOn = now,
+                Active = true
+            });
+
+        var adminUserId = 1;
+
+        var recipes = GetSampleRecipes(adminUserId, now);
+
+        foreach (var recipe in recipes)
+        {
+            Insert.IntoTable(TableName<Recipe>())
+                .Row(recipe.RecipeData);
+
+            foreach (var ingredient in recipe.Ingredients)
+            {
+                Insert.IntoTable(TableName<Ingredient>())
+                    .Row(ingredient);
+            }
+
+            foreach (var instruction in recipe.Instructions)
+            {
+                Insert.IntoTable(TableName<Instruction>())
+                    .Row(instruction);
+            }
+
+            foreach (var dishType in recipe.DishTypes)
+            {
+                Insert.IntoTable(TableName<Domain.Entities.RecipeDishType>())
+                    .Row(dishType);
+            }
+        }
+    }
+
+    private static List<RecipeDataModel> GetSampleRecipes(long userId, DateTime createdOn)
+    {
+        return new List<RecipeDataModel>
+        {
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Pancakes Clássicos",
+                    CookingTimeId = (int)RecipeCookingTime.Between_10_30_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Low,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "2 xícaras de farinha de trigo", RecipeId = 1, CreatedOn = createdOn, Active = true },
+                    new { Item = "2 colheres de sopa de açúcar", RecipeId = 1, CreatedOn = createdOn, Active = true },
+                    new { Item = "2 ovos", RecipeId = 1, CreatedOn = createdOn, Active = true },
+                    new { Item = "1 1/2 xícara de leite", RecipeId = 1, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Misture os ingredientes secos em uma tigela", RecipeId = 1, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Adicione os ovos e o leite, misture bem", RecipeId = 1, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Aqueça a frigideira e despeje a massa", RecipeId = 1, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 1, DishTypeId = 1, CreatedOn = createdOn } // Breakfast
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Salada Caesar",
+                    CookingTimeId = (int)RecipeCookingTime.Less_10_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Low,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Alface romana", RecipeId = 2, CreatedOn = createdOn, Active = true },
+                    new { Item = "Queijo parmesão", RecipeId = 2, CreatedOn = createdOn, Active = true },
+                    new { Item = "Croutons", RecipeId = 2, CreatedOn = createdOn, Active = true },
+                    new { Item = "Molho Caesar", RecipeId = 2, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Lave e corte a alface", RecipeId = 2, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Adicione croutons e queijo", RecipeId = 2, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Regue com molho Caesar", RecipeId = 2, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 2, DishTypeId = 2, CreatedOn = createdOn } // Lunch
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Lasanha Bolonhesa",
+                    CookingTimeId = (int)RecipeCookingTime.Greater_60_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.High,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Massa de lasanha", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Item = "Carne moída", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Item = "Molho de tomate", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Item = "Queijo mozzarella", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Item = "Molho bechamel", RecipeId = 3, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Prepare o molho bolonhesa", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Cozinhe a massa de lasanha", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Monte as camadas alternando massa, molho e queijo", RecipeId = 3, CreatedOn = createdOn, Active = true },
+                    new { Step = 4, Description = "Asse por 45 minutos a 180°C", RecipeId = 3, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 3, DishTypeId = 6, CreatedOn = createdOn } // Dinner
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Smoothie de Frutas",
+                    CookingTimeId = (int)RecipeCookingTime.Less_10_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Low,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "1 banana", RecipeId = 4, CreatedOn = createdOn, Active = true },
+                    new { Item = "1/2 xícara de morangos", RecipeId = 4, CreatedOn = createdOn, Active = true },
+                    new { Item = "1 xícara de leite", RecipeId = 4, CreatedOn = createdOn, Active = true },
+                    new { Item = "1 colher de mel", RecipeId = 4, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Coloque todos os ingredientes no liquidificador", RecipeId = 4, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Bata até ficar homogêneo", RecipeId = 4, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Sirva gelado", RecipeId = 4, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 4, DishTypeId = 7, CreatedOn = createdOn } // Drinks
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Bruschetta Italiana",
+                    CookingTimeId = (int)RecipeCookingTime.Between_10_30_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Low,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Pão italiano fatiado", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Item = "Tomates frescos", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Item = "Manjericão fresco", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Item = "Alho", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Item = "Azeite extra virgem", RecipeId = 5, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Torre o pão até dourar", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Esfregue alho no pão", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Cubra com tomate e manjericão", RecipeId = 5, CreatedOn = createdOn, Active = true },
+                    new { Step = 4, Description = "Regue com azeite", RecipeId = 5, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 5, DishTypeId = 3, CreatedOn = createdOn } // Appetizers
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Bolo de Chocolate",
+                    CookingTimeId = (int)RecipeCookingTime.Between_30_60_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Medium,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "2 xícaras de farinha", RecipeId = 6, CreatedOn = createdOn, Active = true },
+                    new { Item = "1 xícara de chocolate em pó", RecipeId = 6, CreatedOn = createdOn, Active = true },
+                    new { Item = "3 ovos", RecipeId = 6, CreatedOn = createdOn, Active = true },
+                    new { Item = "1 xícara de açúcar", RecipeId = 6, CreatedOn = createdOn, Active = true },
+                    new { Item = "1/2 xícara de óleo", RecipeId = 6, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Misture ingredientes secos", RecipeId = 6, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Adicione ovos e óleo", RecipeId = 6, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Asse por 40 minutos a 180°C", RecipeId = 6, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 6, DishTypeId = 5, CreatedOn = createdOn } // Dessert
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Sanduíche Natural",
+                    CookingTimeId = (int)RecipeCookingTime.Less_10_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Low,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Pão integral", RecipeId = 7, CreatedOn = createdOn, Active = true },
+                    new { Item = "Peito de peru", RecipeId = 7, CreatedOn = createdOn, Active = true },
+                    new { Item = "Queijo branco", RecipeId = 7, CreatedOn = createdOn, Active = true },
+                    new { Item = "Alface", RecipeId = 7, CreatedOn = createdOn, Active = true },
+                    new { Item = "Tomate", RecipeId = 7, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Corte o pão ao meio", RecipeId = 7, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Monte o sanduíche com os ingredientes", RecipeId = 7, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Sirva imediatamente", RecipeId = 7, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 7, DishTypeId = 4, CreatedOn = createdOn } // Snack
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Risotto de Cogumelos",
+                    CookingTimeId = (int)RecipeCookingTime.Between_30_60_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.High,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Arroz arbóreo", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Item = "Cogumelos variados", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Item = "Caldo de legumes", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Item = "Vinho branco", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Item = "Queijo parmesão", RecipeId = 8, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Refogue os cogumelos", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Adicione o arroz e o vinho", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Vá adicionando o caldo aos poucos", RecipeId = 8, CreatedOn = createdOn, Active = true },
+                    new { Step = 4, Description = "Finalize com queijo parmesão", RecipeId = 8, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 8, DishTypeId = 6, CreatedOn = createdOn } // Dinner
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Salada de Frutas",
+                    CookingTimeId = (int)RecipeCookingTime.Less_10_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Low,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Maçã", RecipeId = 9, CreatedOn = createdOn, Active = true },
+                    new { Item = "Banana", RecipeId = 9, CreatedOn = createdOn, Active = true },
+                    new { Item = "Uvas", RecipeId = 9, CreatedOn = createdOn, Active = true },
+                    new { Item = "Laranja", RecipeId = 9, CreatedOn = createdOn, Active = true },
+                    new { Item = "Mel", RecipeId = 9, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Corte todas as frutas em pedaços", RecipeId = 9, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Misture em uma tigela", RecipeId = 9, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Regue com mel", RecipeId = 9, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 9, DishTypeId = 5, CreatedOn = createdOn } // Dessert
+                }
+            },
+            new RecipeDataModel
+            {
+                RecipeData = new
+                {
+                    Title = "Frango Grelhado",
+                    CookingTimeId = (int)RecipeCookingTime.Between_30_60_Minutes,
+                    DifficultyId = (int)RecipeDifficulty.Medium,
+                    UserId = userId,
+                    CreatedOn = createdOn,
+                    Active = true
+                },
+                Ingredients = new[]
+                {
+                    new { Item = "Peito de frango", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Item = "Azeite", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Item = "Alho", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Item = "Ervas finas", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Item = "Sal e pimenta", RecipeId = 10, CreatedOn = createdOn, Active = true }
+                },
+                Instructions = new[]
+                {
+                    new { Step = 1, Description = "Tempere o frango com sal, pimenta e ervas", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Step = 2, Description = "Aqueça a grelha com azeite", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Step = 3, Description = "Grelhe por 15 minutos de cada lado", RecipeId = 10, CreatedOn = createdOn, Active = true },
+                    new { Step = 4, Description = "Sirva quente", RecipeId = 10, CreatedOn = createdOn, Active = true }
+                },
+                DishTypes = new[]
+                {
+                    new { RecipeId = 10, DishTypeId = 2, CreatedOn = createdOn } // Lunch
+                }
+            }
+        };
+    }
+    private class RecipeDataModel
+    {
+        public object RecipeData { get; set; } = null!; 
+        public object[] Ingredients { get; set; } = [];
+        public object[] Instructions { get; set; } = [];
+        public object[] DishTypes { get; set; } = [];
+    }
+
+    
+}
+

--- a/src/backend/MyRecipeBook.Infrastructure/Migrations/Versions/Version0000003.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Migrations/Versions/Version0000003.cs
@@ -376,7 +376,7 @@ public class Version0000003 : VersionBase
             }
         };
     }
-    private class RecipeDataModel
+    sealed class RecipeDataModel
     {
         public object RecipeData { get; set; } = null!; 
         public object[] Ingredients { get; set; } = [];

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MyRecipeBook.Application.Services.AutoMapper;
 using MyRecipeBook.Application.UseCases.Login.DoLogin;
 using MyRecipeBook.Application.UseCases.Recipe.Filter;
+using MyRecipeBook.Application.UseCases.Recipe.GetById;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
 using MyRecipeBook.Application.UseCases.User.ChangePassword;
 using MyRecipeBook.Application.UseCases.User.Profile;
@@ -18,11 +19,26 @@ namespace MyRecipeBook.Application
 
         public static void AddApplication(this IServiceCollection services, IConfiguration configuration)
         {
-            AddAutoMapper(services, configuration);
+            AddAutoMapper(services);
+            AddIdEnconder(services, configuration);
             AddUseCases(services);
         }
 
-        private static void AddAutoMapper(IServiceCollection services, IConfiguration configuration)
+        private static void AddAutoMapper(IServiceCollection services)
+        {
+
+
+            services.AddScoped(options => new AutoMapper.MapperConfiguration(autoMapperOptions =>
+            {
+                var sqids = options.GetService<SqidsEncoder<long>>()!;
+
+                autoMapperOptions.AddProfile(new AutoMapping(sqids));
+            }).CreateMapper());
+
+
+        }
+
+        private static void AddIdEnconder(IServiceCollection services, IConfiguration configuration)
         {
             var sqids = new SqidsEncoder<long>(new()
             {
@@ -30,14 +46,7 @@ namespace MyRecipeBook.Application
                 Alphabet = configuration.GetValue<string>("Settings:IdCryptographyAlphabet")!,
             });
 
-            var autoMapper = new AutoMapper.MapperConfiguration(options =>
-            {
-                options.AddProfile(new AutoMapping(sqids));
-            });
-
-
-
-            services.AddScoped(options => autoMapper.CreateMapper());
+            services.AddSingleton(sqids);
         }
 
         private static void AddUseCases(IServiceCollection services)
@@ -49,6 +58,7 @@ namespace MyRecipeBook.Application
             services.AddScoped<IChangePasswordUseCase, ChangePasswordUseCase>();
             services.AddScoped<IRegisterRecipeUseCase, RegisterRecipeUseCase>();
             services.AddScoped<IFilterRecipeUseCase, FilterRecipeUseCase>();
+            services.AddScoped<IGetRecipeByIdUseCase, GetRecipeByIdUseCase>();
         }
 
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Services/AutoMapper/AutoMapping.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/Services/AutoMapper/AutoMapping.cs
@@ -59,12 +59,27 @@ namespace MyRecipeBook.Application.Services.AutoMapper
         {
             CreateMap<Domain.Entities.User, ResponseUserProfileJson>();
 
+            CreateMap<Domain.Entities.CookingTime, ResponseCookingTimeJson>();
+            CreateMap<Domain.Entities.Difficulty, ResponseDifficultyJson>();
+            CreateMap<Domain.Entities.RecipeDishType, ResponseRecipeDishTypeJson>();
+            CreateMap<Domain.Entities.DishType, ResponseDishTypesJson>();
+            CreateMap<Domain.Entities.Ingredient, ResponseIngredientJson>();
+            CreateMap<Domain.Entities.Instruction, ResponseInstructionJson>();
+
+
             CreateMap<Domain.Entities.Recipe, ResponseRegisteredRecipeJson>()
                 .ForMember(dest => dest.Id, config => config.MapFrom(src => _idEncoder.Encode(src.Id)));
 
             CreateMap<Domain.Entities.Recipe, ResponseShortRecipeJson>()
                 .ForMember(dest => dest.Id, config => config.MapFrom(src => _idEncoder.Encode(src.Id)))
                 .ForMember(dest => dest.AmountIngredients, config => config.MapFrom(src => src.Ingredients.Count));
+
+            CreateMap<Domain.Entities.Recipe, ResponseRecipeJson>()
+                .ForMember(dest => dest.Id,
+                            opt => opt.MapFrom(src => _idEncoder.Encode(src.Id)))
+                .ForMember(dest => dest.DishTypes,
+                            opt => opt.MapFrom(
+                                src => src.RecipeDishTypes.Select(recipeDishType => recipeDishType.DishType)));
         }
 
     }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/GetRecipeByIdUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/GetRecipeByIdUseCase.cs
@@ -23,7 +23,7 @@ namespace MyRecipeBook.Application.UseCases.Recipe.GetById
         {
             var loggedUser = await _loggedUSer.User();
 
-            var recipe = await _repository.GetById(loggedUser.Id, request);
+            var recipe = await _repository.GetById(loggedUser, request );
 
             if (recipe is null)
                 throw new NotFoundException(ResourceMessageHelper.FieldNotFound("Recipe"));

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/GetRecipeByIdUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/GetRecipeByIdUseCase.cs
@@ -1,0 +1,34 @@
+﻿using AutoMapper;
+using MyRecipeBook.Communication.Response;
+using MyRecipeBook.Domain.Repositories.Recipe;
+using MyRecipeBook.Domain.Services.LoggedUser;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.GetById
+{
+    public class GetRecipeByIdUseCase : IGetRecipeByIdUseCase
+    {
+        private readonly IMapper _mapper;
+        private readonly ILoggedUser _loggedUSer;
+        private readonly IRecipeReadOnlyRepository _repository;
+
+        public GetRecipeByIdUseCase(IMapper mapper, ILoggedUser loggedUSer, IRecipeReadOnlyRepository repository)
+        {
+            _mapper = mapper;
+            _loggedUSer = loggedUSer;
+            _repository = repository;
+        }
+
+        public async Task<ResponseRecipeJson> Execute(long request)
+        {
+            var loggedUser = await _loggedUSer.User();
+
+            var recipe = await _repository.GetById(loggedUser.Id, request);
+
+            if (recipe is null)
+                throw new NotFoundException(ResourceMessageHelper.FieldNotFound("Recipe"));
+
+            return _mapper.Map<ResponseRecipeJson>(recipe);
+        }
+    }
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/IGetRecipeByIdUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/IGetRecipeByIdUseCase.cs
@@ -1,0 +1,9 @@
+﻿using MyRecipeBook.Communication.Response;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.GetById
+{
+    public interface IGetRecipeByIdUseCase
+    {
+        Task<ResponseRecipeJson> Execute(long request);
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseCookingTimeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseCookingTimeJson.cs
@@ -1,0 +1,8 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseCookingTimeJson
+    {
+        public int Id { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseDifficultyJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseDifficultyJson.cs
@@ -1,0 +1,8 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseDifficultyJson
+    {
+        public int Id { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseDishTypesJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseDishTypesJson.cs
@@ -1,0 +1,8 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseDishTypesJson
+    {
+        public int Id { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseIngredientJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseIngredientJson.cs
@@ -1,0 +1,8 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseIngredientJson
+    {
+        public long Id { get; set; }
+        public string Item { get; set; } = string.Empty;
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseInstructionJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseInstructionJson.cs
@@ -1,0 +1,9 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseInstructionJson
+    {
+        public long Id { get; set; }
+        public int Step { get; set; }
+        public string Description { get; set; } = string.Empty;
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseRecipeDishTypeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseRecipeDishTypeJson.cs
@@ -1,0 +1,10 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseRecipeDishTypeJson
+    {
+        public int RecipeId { get; set; }
+        public int DishTypeId { get; set; }
+        public ResponseDishTypesJson? DishType { get; set; }
+
+    }
+}

--- a/src/shared/MyRecipeBook.Communucation/Response/ResponseRecipeJson.cs
+++ b/src/shared/MyRecipeBook.Communucation/Response/ResponseRecipeJson.cs
@@ -1,0 +1,14 @@
+﻿namespace MyRecipeBook.Communication.Response
+{
+    public class ResponseRecipeJson
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public IList<ResponseIngredientJson> Ingredients { get; set; } = [];
+        public IList<ResponseInstructionJson> Instructions { get; set; } = [];
+        public IList<ResponseDishTypesJson> DishTypes { get; set; } = [];
+        public ResponseCookingTimeJson? CookingTime { get; set; }
+        public ResponseDifficultyJson? Difficulty { get; set; }
+
+    }
+}

--- a/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/ErrorOnValidationException.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/ErrorOnValidationException.cs
@@ -1,12 +1,18 @@
-﻿namespace MyRecipeBook.Exceptions.ExceptionsBase
+﻿using System.Net;
+
+namespace MyRecipeBook.Exceptions.ExceptionsBase
 {
     public class ErrorOnValidationException : MyRecipeBookException
     {
-        public IList<string> ErrorMessages { get; set; }
+        private readonly IList<string> ErrorMessages;
 
-        public ErrorOnValidationException(IList<string> erros)  : base(string.Empty)
+        public ErrorOnValidationException(IList<string> errors) : base(string.Empty)
         {
-            ErrorMessages = erros;
+            ErrorMessages = errors;
         }
+
+        public override IList<string> GetErrorMessages() => ErrorMessages;
+
+        public override HttpStatusCode GetStatusCode() => HttpStatusCode.BadRequest;
     }
 }

--- a/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/MyRecipeBookException.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/MyRecipeBookException.cs
@@ -4,7 +4,7 @@ namespace MyRecipeBook.Exceptions.ExceptionsBase
 {
     public abstract class MyRecipeBookException : SystemException
     {
-        public MyRecipeBookException(string message) : base(message) { }
+        protected MyRecipeBookException(string message) : base(message) { }
         public abstract IList<string> GetErrorMessages();
         public abstract HttpStatusCode GetStatusCode();
     }

--- a/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/MyRecipeBookException.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/MyRecipeBookException.cs
@@ -1,4 +1,11 @@
-﻿namespace MyRecipeBook.Exceptions.ExceptionsBase
+﻿using System.Net;
+
+namespace MyRecipeBook.Exceptions.ExceptionsBase
 {
-    public class MyRecipeBookException(string message) : SystemException(message) {}
+    public abstract class MyRecipeBookException : SystemException
+    {
+        public MyRecipeBookException(string message) : base(message) { }
+        public abstract IList<string> GetErrorMessages();
+        public abstract HttpStatusCode GetStatusCode();
+    }
 }

--- a/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/NotFoundException.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/NotFoundException.cs
@@ -1,0 +1,15 @@
+﻿using System.Net;
+
+namespace MyRecipeBook.Exceptions.ExceptionsBase
+{
+    public class NotFoundException : MyRecipeBookException
+    {
+        public NotFoundException(string message) : base(message)
+        {
+        }
+
+        public override IList<string> GetErrorMessages() => [Message];
+
+        public override HttpStatusCode GetStatusCode() => HttpStatusCode.NotFound;
+    }
+}

--- a/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/ResourceMessageHelper.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/ResourceMessageHelper.cs
@@ -31,5 +31,9 @@
         {
             return string.Format(ResourceMessagesException.FIELD_TWO_OR_MORE_SAME_ORDER, fieldName);
         }
+        public static string FieldNotFound(string fieldName)
+        {
+            return string.Format(ResourceMessagesException.FIELD_NOT_FOUND, fieldName);
+        }
     }
 }

--- a/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/UnauthorizedException.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ExceptionsBase/UnauthorizedException.cs
@@ -2,9 +2,9 @@
 
 namespace MyRecipeBook.Exceptions.ExceptionsBase
 {
-    public class InvalidLoginException : MyRecipeBookException
+    public class UnauthorizedException : MyRecipeBookException
     {
-        public InvalidLoginException() : base(ResourceMessagesException.EMAIL_OR_PASSWORD_INVALID)
+        public UnauthorizedException(string message) : base(message)
         {
         }
 

--- a/src/shared/MyRecipeBook.Exceptions/ResourceMessagesException.Designer.cs
+++ b/src/shared/MyRecipeBook.Exceptions/ResourceMessagesException.Designer.cs
@@ -133,6 +133,15 @@ namespace MyRecipeBook.Exceptions {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No &apos;{0}&apos; was found..
+        /// </summary>
+        public static string FIELD_NOT_FOUND {
+            get {
+                return ResourceManager.GetString("FIELD_NOT_FOUND", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value entered in &apos;{0}&apos; is not allowed based on current system rules..
         /// </summary>
         public static string FIELD_NOT_SUPPORTED {

--- a/src/shared/MyRecipeBook.Exceptions/ResourceMessagesException.pt-BR.resx
+++ b/src/shared/MyRecipeBook.Exceptions/ResourceMessagesException.pt-BR.resx
@@ -168,4 +168,7 @@
   <data name="FIELD_TWO_OR_MORE_SAME_ORDER" xml:space="preserve">
     <value>O campo '{0}' deve conter valores únicos.</value>
   </data>
+  <data name="FIELD_NOT_FOUND" xml:space="preserve">
+    <value>Não foi encontrado nenhum registro de '{0}'.</value>
+  </data>
 </root>

--- a/src/shared/MyRecipeBook.Exceptions/ResourceMessagesException.resx
+++ b/src/shared/MyRecipeBook.Exceptions/ResourceMessagesException.resx
@@ -168,4 +168,7 @@
   <data name="FIELD_TWO_OR_MORE_SAME_ORDER" xml:space="preserve">
     <value>The '{0}' field must contain only unique values.</value>
   </data>
+  <data name="FIELD_NOT_FOUND" xml:space="preserve">
+    <value>No '{0}' was found.</value>
+  </data>
 </root>

--- a/tests/UseCases.Test/Recipe/Filter/FilterRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Filter/FilterRecipeUseCaseTest.cs
@@ -47,8 +47,8 @@ namespace UseCases.Test.Recipe.Filter
 
             var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
             ex.ShouldSatisfyAllConditions(
-                () => ex.ErrorMessages.Count.ShouldBe(1),
-                () => ex.ErrorMessages.ShouldContain(ResourceMessageHelper.FieldNotSupported("CookingTime"))
+                () => ex.GetErrorMessages().Count.ShouldBe(1),
+                () => ex.GetErrorMessages().ShouldContain(ResourceMessageHelper.FieldNotSupported("CookingTime"))
             );
 
         }

--- a/tests/UseCases.Test/Recipe/GetById/GetRecipeByIdUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/GetById/GetRecipeByIdUseCaseTest.cs
@@ -1,0 +1,63 @@
+﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.LoggedUser;
+using CommonTestUtilities.Mapper;
+using CommonTestUtilities.Repositories;
+using MyRecipeBook.Application.UseCases.Recipe.GetById;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+using Shouldly;
+
+namespace UseCases.Test.Recipe.GetById
+{
+    public class GetRecipeByIdUseCaseTest
+    {
+
+        [Fact]
+        public async Task Success()
+        {
+            (var user, _) = UserBuilder.Build();
+
+            var recipe = RecipeBuilder.Build(user);
+
+            var useCase = CreateUseCase(user, recipe);
+
+            var result = await useCase.Execute(recipe.Id);
+
+            result.ShouldNotBeNull();
+            result.Id.ShouldNotBeNullOrWhiteSpace();
+            result.Title.ShouldBe(recipe.Title);
+
+        }
+
+        [Fact]
+        public async Task Error_Recipe_NotFound()
+        {
+            (var user, _) = UserBuilder.Build();
+
+            var useCase = CreateUseCase(user);
+
+            async Task act() { await useCase.Execute(request: 1000); }
+
+            var ex = await Should.ThrowAsync<NotFoundException>(act);
+
+            ex.ShouldSatisfyAllConditions(
+                () => ex.GetErrorMessages().Count.ShouldBe(1),
+                () => ex.GetErrorMessages().ShouldContain(ResourceMessageHelper.FieldNotFound("Recipe"))
+            );
+
+        }
+
+
+
+        private static GetRecipeByIdUseCase CreateUseCase(
+            MyRecipeBook.Domain.Entities.User user,
+            MyRecipeBook.Domain.Entities.Recipe? recipe = null
+            )
+        {
+            var mapper = MapperBuilder.Build();
+            var loggedUser = LoggedUserBuilder.Build(user);
+            var repository = new RecipeReadOnlyRepositoryBuilder().GetById(user, recipe).Build();
+
+            return new GetRecipeByIdUseCase(mapper, loggedUser, repository);
+        }
+    }
+}

--- a/tests/UseCases.Test/Recipe/Register/RegisterRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Register/RegisterRecipeUseCaseTest.cs
@@ -42,8 +42,8 @@ namespace UseCases.Test.Recipe.Register
             var ex = await Should.ThrowAsync<ErrorOnValidationException>(action);
 
             ex.ShouldSatisfyAllConditions(
-                () => ex.ErrorMessages.Count.ShouldBe(1),
-                () => ex.ErrorMessages.ShouldContain(ResourceMessageHelper.FieldEmpty("Title"))
+                () => ex.GetErrorMessages().Count.ShouldBe(1),
+                () => ex.GetErrorMessages().ShouldContain(ResourceMessageHelper.FieldEmpty("Title"))
             );
         }
 

--- a/tests/UseCases.Test/User/ChangePassword/ChangePasswordUseCaseTest.cs
+++ b/tests/UseCases.Test/User/ChangePassword/ChangePasswordUseCaseTest.cs
@@ -53,12 +53,12 @@ public class ChangePasswordUseCaseTest
 
         var useCase = CreateUseCase(user);
 
-        Func<Task> act = async () =>{ await useCase.Execute(request); };
+        Func<Task> act = async () => { await useCase.Execute(request); };
 
         var exception = await act.ShouldThrowAsync<ErrorOnValidationException>();
 
-        exception.ErrorMessages.ShouldHaveSingleItem();
-        exception.ErrorMessages.ShouldContain(ResourceMessagesException.PASSWORD_EMPTY);
+        exception.GetErrorMessages().ShouldHaveSingleItem();
+        exception.GetErrorMessages().ShouldContain(ResourceMessagesException.PASSWORD_EMPTY);
 
         var passwordEncripter = PasswordEncripterBuilder.Build();
 
@@ -75,7 +75,7 @@ public class ChangePasswordUseCaseTest
 
         var useCase = CreateUseCase(user);
 
-        Func<Task> act = async () =>{ await useCase.Execute(request); };
+        Func<Task> act = async () => { await useCase.Execute(request); };
 
         var exception = await act.ShouldThrowAsync<ErrorOnValidationException>();
 

--- a/tests/UseCases.Test/User/ChangePassword/ChangePasswordUseCaseTest.cs
+++ b/tests/UseCases.Test/User/ChangePassword/ChangePasswordUseCaseTest.cs
@@ -79,8 +79,8 @@ public class ChangePasswordUseCaseTest
 
         var exception = await act.ShouldThrowAsync<ErrorOnValidationException>();
 
-        exception.ErrorMessages.ShouldHaveSingleItem();
-        exception.ErrorMessages.ShouldContain(ResourceMessagesException.PASSWORD_DIFFERENT_CURRENT_PASSWORD);
+        exception.GetErrorMessages().ShouldHaveSingleItem();
+        exception.GetErrorMessages().ShouldContain(ResourceMessagesException.PASSWORD_DIFFERENT_CURRENT_PASSWORD);
 
         var passwordEncripter = PasswordEncripterBuilder.Build();
 

--- a/tests/UseCases.Test/User/Register/RegisterUserUseCaseTest.cs
+++ b/tests/UseCases.Test/User/Register/RegisterUserUseCaseTest.cs
@@ -20,7 +20,7 @@ namespace UseCases.Test.User.Register
             var useCase = CreateUseCase();
 
             var result = await useCase.Execute(request);
-             
+
             result.ShouldNotBeNull();
             result.Tokens.ShouldNotBeNull();
             result.Name.ShouldBe(request.Name);
@@ -37,7 +37,7 @@ namespace UseCases.Test.User.Register
             Func<Task> act = async () => await useCase.Execute(request);
 
             var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
-            ex.ErrorMessages.ShouldSatisfyAllConditions(
+            ex.GetErrorMessages().ShouldSatisfyAllConditions(
                 list => list.Count.ShouldBe(1),
                 list => list.ShouldContain(ResourceMessagesException.EMAIL_ALREADY_REGISTERED)
             );
@@ -54,7 +54,7 @@ namespace UseCases.Test.User.Register
             Func<Task> act = async () => await useCase.Execute(request);
 
             var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
-            ex.ErrorMessages.ShouldSatisfyAllConditions(
+            ex.GetErrorMessages().ShouldSatisfyAllConditions(
                 list => list.Count.ShouldBe(1),
                 list => list.ShouldContain(ResourceMessagesException.NAME_EMPTY)
             );

--- a/tests/UseCases.Test/User/Update/UpdateUserUseCaseTest.cs
+++ b/tests/UseCases.Test/User/Update/UpdateUserUseCaseTest.cs
@@ -22,7 +22,7 @@ namespace UseCases.Test.User.Update
             var useCase = CreateUseCase(user);
 
             Func<Task> act = async () => await useCase.Execute(request);
-             
+
             await act.ShouldNotThrowAsync();
 
             user.Name.ShouldBe(request.Name);
@@ -39,10 +39,10 @@ namespace UseCases.Test.User.Update
 
             var useCase = CreateUseCase(user);
 
-            Func<Task> act = async () => { await useCase.Execute(request); };
+            async Task act() { await useCase.Execute(request); }
 
             var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
-            ex.ErrorMessages.ShouldSatisfyAllConditions(
+            ex.GetErrorMessages().ShouldSatisfyAllConditions(
                 list => list.Count.ShouldBe(1),
                 list => list.ShouldContain(ResourceMessagesException.NAME_EMPTY)
             );
@@ -63,7 +63,7 @@ namespace UseCases.Test.User.Update
             async Task act() { await useCase.Execute(request); }
 
             var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
-            ex.ErrorMessages.ShouldSatisfyAllConditions(
+            ex.GetErrorMessages().ShouldSatisfyAllConditions(
                 list => list.Count.ShouldBe(1),
                 list => list.ShouldContain(ResourceMessagesException.EMAIL_ALREADY_REGISTERED)
             );

--- a/tests/WebApi.test/CustomWebApplicationFactory.cs
+++ b/tests/WebApi.test/CustomWebApplicationFactory.cs
@@ -1,10 +1,12 @@
 ﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.IdEncryption;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using MyRecipeBook.Domain.Enums;
 using MyRecipeBook.Infrastructure.DataAccess;
+using Sqids;
 
 namespace WebApi.test
 {
@@ -50,6 +52,7 @@ namespace WebApi.test
         public Guid GetUserIdentifier() => _user.UserIdentifier;
 
         public string GetRecipeTitle() => _recipe.Title;
+        public string GetRecipeId() => IdEncripterBuilder.Build().Encode(_recipe.Id);
         public RecipeDifficulty? GetDifficulty() => _recipe.DifficultyId;
         public RecipeCookingTime? GetRecipeCookingTime() => _recipe.CookingTimeId;
         public IList<RecipeDishType>? GetRecipeDishType() => _recipe.RecipeDishTypes.Select(rdt => rdt.DishTypeId).ToList();

--- a/tests/WebApi.test/Recipe/GetById/GetRecipeByIdInvalidTokenTest.cs
+++ b/tests/WebApi.test/Recipe/GetById/GetRecipeByIdInvalidTokenTest.cs
@@ -1,0 +1,48 @@
+﻿using CommonTestUtilities.IdEncryption;
+using CommonTestUtilities.Requests;
+using CommonTestUtilities.Tokens;
+using Shouldly;
+using System.Net;
+
+namespace WebApi.test.Recipe.GetById
+{
+    public class GetRecipeByIdInvalidTokenTest : MyRecipeBookClassFixture
+    {
+        private const string METHOD = "recipe";
+        private const string INVALID_TOKEN = "123";
+        public GetRecipeByIdInvalidTokenTest(CustomWebApplicationFactory factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task Error_Invalid_Token()
+        {
+            var id = IdEncripterBuilder.Build().Encode(1);
+
+            var response = await DoGet(method: $"{METHOD}/{id}", token: INVALID_TOKEN);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task Error_Without_Token()
+        {
+            var id = IdEncripterBuilder.Build().Encode(1);
+
+            var response = await DoGet(method: $"{METHOD}/{id}", token: string.Empty);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+        [Fact]
+        public async Task Error_NotFound_User_Token()
+        {
+            var id = IdEncripterBuilder.Build().Encode(1);
+
+            var token = JwtTokensGeneratorBuilder.Build().Generate(Guid.NewGuid());
+
+            var response = await DoGet(method: $"{METHOD}/{id}", token: token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+    }
+}

--- a/tests/WebApi.test/Recipe/GetById/GetRecipeByIdTest.cs
+++ b/tests/WebApi.test/Recipe/GetById/GetRecipeByIdTest.cs
@@ -1,0 +1,70 @@
+﻿using CommonTestUtilities.IdEncryption;
+using CommonTestUtilities.Requests;
+using CommonTestUtilities.Tokens;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+using WebApi.test.InlineData;
+
+namespace WebApi.test.Recipe.GetById
+{
+    public class GetRecipeByIdTest : MyRecipeBookClassFixture
+    {
+        private const string METHOD = "recipe";
+        
+        private readonly Guid _userIdentifer;
+        private readonly string _recipeId;
+        private readonly string _recipeTitle;
+
+        private readonly string _token;
+
+        public GetRecipeByIdTest(CustomWebApplicationFactory factory) : base(factory)
+        {
+            _userIdentifer = factory.GetUserIdentifier();
+            _recipeId = factory.GetRecipeId();
+            _recipeTitle = factory.GetRecipeTitle();
+            _token = JwtTokensGeneratorBuilder.Build().Generate(_userIdentifer);
+        }
+
+        [Fact]
+        public async Task Success()
+        {
+            var response = await DoGet(method: $"{METHOD}/{_recipeId}", token: _token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            await using var responseBody = await response.Content.ReadAsStreamAsync();
+
+            var responseData = await JsonDocument.ParseAsync(responseBody);
+
+            responseData.RootElement.GetProperty("id").GetString().ShouldBe(_recipeId);
+            responseData.RootElement.GetProperty("title").GetString().ShouldBe(_recipeTitle);
+        }
+
+        [Theory]
+        [ClassData(typeof(CultureInlineDataTest))]
+        public async Task Error_Recipe_Not_Found(string culture)
+        {
+            var id = IdEncripterBuilder.Build().Encode(1000);
+
+            var response = await DoGet(method: $"{METHOD}/{id}", token: _token, culture: culture);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+
+            await using var responseBody = await response.Content.ReadAsStreamAsync();
+
+            var responseData = await JsonDocument.ParseAsync(responseBody);
+
+            var errors = responseData.RootElement.GetProperty("errors").EnumerateArray();
+
+            var expectedMessage = ResourceMessageHelper.FieldNotFound(fieldName: "Recipe");
+
+            errors.ShouldSatisfyAllConditions(
+               e => e.ShouldHaveSingleItem(),
+               e => e.Single().GetString()!.Equals(expectedMessage)
+           );
+        }
+
+    }
+}


### PR DESCRIPTION
- Introduce `MyRecipeBookIdBinder` to decode Sqids hash ➜ long.
- Add `GET /recipe/{id}` action wired to new `IGetRecipeByIdUseCase`.
- Extend repository with `GetById` query including navigation collections.
- Create rich response DTOs (ingredients, instructions, dish types, etc.) and AutoMapper maps.
- Register Sqids encoder as singleton and wire AutoMapper at runtime.
- Replace scatter-shot checks with polymorphic `MyRecipeBookException` hierarchy (`NotFound`, `Unauthorized`, `InvalidLogin`, `ErrorOnValidation`); `ExceptionFilter` now relies on `GetStatusCode()` / `GetErrorMessages()`.
- Update filters, tests and resource files to leverage new exception model.