### PR TITLE
Add recipe update feature (PUT /recipe/{id})

### DIFF
--- a/CommonTestUtilities/Repositories/RecipeUpdateOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/RecipeUpdateOnlyRepositoryBuilder.cs
@@ -1,0 +1,25 @@
+﻿using Moq;
+using MyRecipeBook.Domain.Dtos;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Repositories.Recipe;
+
+namespace CommonTestUtilities.Repositories
+{
+    public class RecipeUpdateOnlyRepositoryBuilder
+    {
+        private readonly Mock<IRecipeUpdateOnlyRepository> _repository;
+
+        public RecipeUpdateOnlyRepositoryBuilder() => _repository = new Mock<IRecipeUpdateOnlyRepository>();
+
+        public RecipeUpdateOnlyRepositoryBuilder GetById(User user,Recipe? recipe)
+        {
+            if (recipe is not null)
+                _repository.Setup(repository => repository.GetById(user, recipe.Id)).ReturnsAsync(recipe);
+
+            return this;
+        }
+
+     
+        public IRecipeUpdateOnlyRepository Build() => _repository.Object;
+    }
+}

--- a/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
@@ -5,6 +5,7 @@ using MyRecipeBook.Application.UseCases.Recipe.Delete;
 using MyRecipeBook.Application.UseCases.Recipe.Filter;
 using MyRecipeBook.Application.UseCases.Recipe.GetById;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
+using MyRecipeBook.Application.UseCases.Recipe.Update;
 using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Response;
 
@@ -56,6 +57,21 @@ namespace MyRecipeBook.API.Controllers
             var response = await useCase.Execute(id);
 
             return Ok(response);
+        }
+
+        [HttpPut]
+        [Route("{id}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status404NotFound)]
+        public async Task<IActionResult> Update(
+            [FromServices] IUpdateRecipeUseCase useCase,
+            [FromRoute][ModelBinder(typeof(MyRecipeBookIdBinder))] long id,
+            [FromBody] RequestRecipeJson request
+        )
+        {
+            await useCase.Execute(id, request);
+
+            return NoContent();
         }
 
         [HttpDelete]

--- a/src/backend/MyRecipeBook.Domain/Repositories/CookingTime/ICookingTimeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/CookingTime/ICookingTimeReadOnlyRepository.cs
@@ -1,6 +1,4 @@
-﻿using MyRecipeBook.Domain.Enums;
-
-namespace MyRecipeBook.Domain.Repositories.CookingTime
+﻿namespace MyRecipeBook.Domain.Repositories.CookingTime
 {
     public interface ICookingTimeReadOnlyRepository
     {

--- a/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeUpdateOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeUpdateOnlyRepository.cs
@@ -1,0 +1,8 @@
+﻿namespace MyRecipeBook.Domain.Repositories.Recipe
+{
+    public interface IRecipeUpdateOnlyRepository
+    {
+        Task<Entities.Recipe?> GetById(Entities.User user, long recipeId);
+        void Update(Entities.Recipe recipe);
+    }
+}

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Query;
 using MyRecipeBook.Domain.Dtos;
 using MyRecipeBook.Domain.Entities;
 using MyRecipeBook.Domain.Extension;
@@ -6,7 +7,7 @@ using MyRecipeBook.Domain.Repositories.Recipe;
 
 namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 {
-    public class RecipeRepository : IRecipeWriteOnlyRepository, IRecipeReadOnlyRepository
+    public class RecipeRepository : IRecipeWriteOnlyRepository, IRecipeReadOnlyRepository, IRecipeUpdateOnlyRepository
     {
         private readonly MyRecipeBookDbContext _dbContext;
 
@@ -53,19 +54,35 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
             return await query.ToListAsync();
         }
 
-        public async Task<Recipe?> GetById(User user, long recipeId)
+        async Task<Recipe?> IRecipeReadOnlyRepository.GetById(User user, long recipeId)
         {
-            return await _dbContext.Recipes
+            return await GetFullRecipe()
                 .AsNoTracking()
+                .FirstOrDefaultAsync(r => r.Id == recipeId &&
+                                          r.UserId == user.Id &&
+                                          r.Active);
+        }
+
+        async Task<Recipe?> IRecipeUpdateOnlyRepository.GetById(User user, long recipeId) 
+        {
+            return await GetFullRecipe()
+                .FirstOrDefaultAsync(r => r.Id == recipeId &&
+                                        r.UserId == user.Id &&
+                                        r.Active);
+        }
+        public void Update(Recipe recipe) => _dbContext.Recipes.Update(recipe);
+
+        private IIncludableQueryable<Recipe, IList<Instruction>> GetFullRecipe()
+        {
+            return _dbContext
+                .Recipes
                 .Include(r => r.CookingTime)
                 .Include(r => r.Difficulty)
                 .Include(r => r.RecipeDishTypes)
                     .ThenInclude(rd => rd.DishType)
                 .Include(r => r.Ingredients)
-                .Include(r => r.Instructions)
-                .FirstOrDefaultAsync(r => r.Id == recipeId &&
-                                          r.UserId == user.Id &&
-                                          r.Active);
+                .Include(r => r.Instructions);
         }
+
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
@@ -63,6 +63,7 @@ namespace MyRecipeBook.Infrastructure
 
             services.AddScoped<IRecipeWriteOnlyRepository, RecipeRepository>();
             services.AddScoped<IRecipeReadOnlyRepository, RecipeRepository>();
+            services.AddScoped<IRecipeUpdateOnlyRepository, RecipeRepository>();
 
             services.AddScoped<IRecipesDishTypeWriteOnlyRepository, RecipesDishTypeRepository>();
         }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
@@ -6,6 +6,7 @@ using MyRecipeBook.Application.UseCases.Recipe.Delete;
 using MyRecipeBook.Application.UseCases.Recipe.Filter;
 using MyRecipeBook.Application.UseCases.Recipe.GetById;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
+using MyRecipeBook.Application.UseCases.Recipe.Update;
 using MyRecipeBook.Application.UseCases.User.ChangePassword;
 using MyRecipeBook.Application.UseCases.User.Profile;
 using MyRecipeBook.Application.UseCases.User.Register;
@@ -62,6 +63,7 @@ namespace MyRecipeBook.Application
             services.AddScoped<IRegisterRecipeUseCase, RegisterRecipeUseCase>();
             services.AddScoped<IFilterRecipeUseCase, FilterRecipeUseCase>();
             services.AddScoped<IGetRecipeByIdUseCase, GetRecipeByIdUseCase>();
+            services.AddScoped<IUpdateRecipeUseCase, UpdateRecipeUseCase>();
             services.AddScoped<IDeleteRecipeUseCase, DeleteRecipeUseCase>();
         }
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/GetRecipeByIdUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/GetRecipeByIdUseCase.cs
@@ -12,18 +12,18 @@ namespace MyRecipeBook.Application.UseCases.Recipe.GetById
         private readonly ILoggedUser _loggedUSer;
         private readonly IRecipeReadOnlyRepository _repository;
 
-        public GetRecipeByIdUseCase(IMapper mapper, ILoggedUser loggedUSer, IRecipeReadOnlyRepository repository)
+        public GetRecipeByIdUseCase(IMapper mapper, ILoggedUser loggedUser, IRecipeReadOnlyRepository repository)
         {
             _mapper = mapper;
-            _loggedUSer = loggedUSer;
+            _loggedUSer = loggedUser;
             _repository = repository;
         }
 
-        public async Task<ResponseRecipeJson> Execute(long request)
+        public async Task<ResponseRecipeJson> Execute(long recipeId)
         {
             var loggedUser = await _loggedUSer.User();
 
-            var recipe = await _repository.GetById(loggedUser, request );
+            var recipe = await _repository.GetById(loggedUser, recipeId);
 
             if (recipe is null)
                 throw new NotFoundException(ResourceMessageHelper.FieldNotFound("Recipe"));

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/IGetRecipeByIdUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/GetById/IGetRecipeByIdUseCase.cs
@@ -4,6 +4,6 @@ namespace MyRecipeBook.Application.UseCases.Recipe.GetById
 {
     public interface IGetRecipeByIdUseCase
     {
-        Task<ResponseRecipeJson> Execute(long request);
+        Task<ResponseRecipeJson> Execute(long recipeId);
     }
 }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Update/IUpdateRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Update/IUpdateRecipeUseCase.cs
@@ -1,0 +1,9 @@
+﻿using MyRecipeBook.Communication.Request;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.Update
+{
+    public interface IUpdateRecipeUseCase
+    {
+        public Task Execute(long recipeId, RequestRecipeJson request);
+    }
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Update/UpdateRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Update/UpdateRecipeUseCase.cs
@@ -1,0 +1,85 @@
+﻿using AutoMapper;
+using MyRecipeBook.Communication.Request;
+using MyRecipeBook.Domain.Extension;
+using MyRecipeBook.Domain.Repositories;
+using MyRecipeBook.Domain.Repositories.CookingTime;
+using MyRecipeBook.Domain.Repositories.Difficulty;
+using MyRecipeBook.Domain.Repositories.DishType;
+using MyRecipeBook.Domain.Repositories.Recipe;
+using MyRecipeBook.Domain.Services.LoggedUser;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.Update
+{
+    public class UpdateRecipeUseCase : IUpdateRecipeUseCase
+    {
+        private readonly ILoggedUser _loggedUser;
+        private readonly IUnitOfWork _unitOfWork;
+        private readonly IMapper _mapper;
+
+        private readonly IRecipeUpdateOnlyRepository _updateRepository;
+        private readonly ICookingTimeReadOnlyRepository _cookingTimeReadOnlyRepository;
+        private readonly IDifficultyReadOnlyRepository _difficultyReadOnlyRepository;
+        private readonly IDishTypeReadOnlyRepository _dishTypeReadOnlyRepository;
+
+        public UpdateRecipeUseCase(ILoggedUser loggedUser, 
+            IUnitOfWork unitOfWork, 
+            IMapper mapper, 
+            IRecipeUpdateOnlyRepository updateRepository,
+            ICookingTimeReadOnlyRepository cookingTimeReadOnlyRepository, 
+            IDifficultyReadOnlyRepository difficultyReadOnlyRepository,
+            IDishTypeReadOnlyRepository dishTypeReadOnlyRepository)
+        {
+            _loggedUser = loggedUser;
+            _unitOfWork = unitOfWork;
+            _mapper = mapper;
+            _updateRepository = updateRepository;
+            _cookingTimeReadOnlyRepository = cookingTimeReadOnlyRepository;
+            _difficultyReadOnlyRepository = difficultyReadOnlyRepository;
+            _dishTypeReadOnlyRepository = dishTypeReadOnlyRepository;
+        }
+
+        public async Task Execute(long recipeId, RequestRecipeJson request)
+        {
+            await Validade(request);
+
+            var loggedUser = await _loggedUser.User();
+
+            var recipe = await _updateRepository.GetById(loggedUser, recipeId);
+
+            if (recipe is null)
+                throw new NotFoundException(ResourceMessageHelper.FieldNotFound("Recipe"));
+            
+            recipe.Ingredients.Clear();
+            recipe.Instructions.Clear();
+            recipe.RecipeDishTypes.Clear();
+
+            _mapper.Map(request, recipe);
+
+            var instructions = request.Instructions.OrderBy(i => i.Step).ToList();
+
+            for (var i = 0; i < instructions.Count; i++)
+                instructions[i].Step = i + 1;
+
+            recipe.Instructions = _mapper.Map<IList<Domain.Entities.Instruction>>(instructions);
+
+            _updateRepository.Update(recipe);
+
+            await _unitOfWork.Commit();
+
+        }
+
+        private async Task Validade(RequestRecipeJson request)
+        {
+            var validator = new RecipeValidator(
+                cookingTimeReadOnlyRepository: _cookingTimeReadOnlyRepository, 
+                difficultyReadOnlyRepository: _difficultyReadOnlyRepository, 
+                dishTypeReadOnlyRepository: _dishTypeReadOnlyRepository);
+
+            var result = await validator.ValidateAsync(request);
+
+            if (result.IsValid.isFalse())
+                throw new ErrorOnValidationException(result.Errors.Select(e => e.ErrorMessage).Distinct().ToList());
+        }
+    }
+}

--- a/tests/UseCases.Test/Recipe/Delete/DeleteRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Delete/DeleteRecipeUseCaseTest.cs
@@ -31,7 +31,7 @@ namespace UseCases.Test.Recipe.Delete
 
             var useCase = CreateUseCase(user);
 
-            async Task act() { await useCase.Execute(id: 1000); }
+            async Task act() { await useCase.Execute(recipeId: 1000); }
 
             var ex = await Should.ThrowAsync<NotFoundException>(act);
 

--- a/tests/UseCases.Test/Recipe/GetById/GetRecipeByIdUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/GetById/GetRecipeByIdUseCaseTest.cs
@@ -6,7 +6,7 @@ using MyRecipeBook.Application.UseCases.Recipe.GetById;
 using MyRecipeBook.Exceptions.ExceptionsBase;
 using Shouldly;
 
-namespace UseCases.Test.Recipe.GetById
+namespace UseCases.Test.Recipe.GetRecipeById
 {
     public class GetRecipeByIdUseCaseTest
     {
@@ -35,7 +35,7 @@ namespace UseCases.Test.Recipe.GetById
 
             var useCase = CreateUseCase(user);
 
-            async Task act() { await useCase.Execute(request: 1000); }
+            async Task act() { await useCase.Execute(recipeId: 1000); }
 
             var ex = await Should.ThrowAsync<NotFoundException>(act);
 

--- a/tests/UseCases.Test/Recipe/Update/UpdateRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Update/UpdateRecipeUseCaseTest.cs
@@ -1,0 +1,95 @@
+﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.LoggedUser;
+using CommonTestUtilities.Mapper;
+using CommonTestUtilities.Repositories;
+using CommonTestUtilities.Requests;
+using MyRecipeBook.Application.UseCases.Recipe.Update;
+using MyRecipeBook.Exceptions.ExceptionsBase;
+using Shouldly;
+
+namespace UseCases.Test.Recipe.Update
+{
+    public class UpdateRecipeUseCaseTest
+    {
+
+        [Fact]
+        public async Task Success()
+        {
+            (var user, _) = UserBuilder.Build();
+            var recipe = RecipeBuilder.Build(user);
+            var request = RequestRecipeJsonBuilder.Build();
+
+            var useCase = CreateUseCase(user, recipe);
+
+            Func<Task> act = async () => await useCase.Execute(recipe.Id, request); 
+
+            await act.ShouldNotThrowAsync();
+        }
+
+        [Fact]
+        public async Task Error_Recipe_NotFound()
+        {
+            (var user, _) = UserBuilder.Build();
+            var recipe = RecipeBuilder.Build(user);
+            var request = RequestRecipeJsonBuilder.Build();
+
+            var useCase = CreateUseCase(user);
+
+            async Task act() { await useCase.Execute(recipeId: user.Id, request); }
+
+            var ex = await Should.ThrowAsync<NotFoundException>(act);
+
+            ex.ShouldSatisfyAllConditions(
+                () => ex.GetErrorMessages().Count.ShouldBe(1),
+                () => ex.GetErrorMessages().ShouldContain(ResourceMessageHelper.FieldNotFound("Recipe"))
+            );
+
+        }
+
+        [Fact]
+        public async Task Error_Title_Empty()
+        {
+            (var user, _) = UserBuilder.Build();
+            var recipe = RecipeBuilder.Build(user);
+            var request = RequestRecipeJsonBuilder.Build();
+            request.Title = string.Empty;
+
+            var useCase = CreateUseCase(user, recipe);
+
+            async Task act() { await useCase.Execute(recipeId: user.Id, request); }
+
+            var ex = await Should.ThrowAsync<ErrorOnValidationException>(act);
+
+            ex.ShouldSatisfyAllConditions(
+                () => ex.GetErrorMessages().Count.ShouldBe(1),
+                () => ex.GetErrorMessages().ShouldContain(ResourceMessageHelper.FieldEmpty("Title"))
+            );
+
+        }
+
+        private static UpdateRecipeUseCase CreateUseCase(
+            MyRecipeBook.Domain.Entities.User user,
+            MyRecipeBook.Domain.Entities.Recipe? recipe = null
+            )
+        {
+            var repositoryCookingTime = new CookingTimeReadOnlyRepositoryBuilder();
+            repositoryCookingTime.ExistsAnyCookingTime();
+
+            var repositoryDifficulty = new DifficultyReadOnlyRepositoryBuilder();
+            repositoryDifficulty.ExistsAnyDifficulty();
+
+            var repositoryDishType = new DishTypeReadOnlyRepositoryBuilder();
+            repositoryDishType.ExistsAnyDishType();
+
+            return new UpdateRecipeUseCase(
+                loggedUser: LoggedUserBuilder.Build(user),
+                unitOfWork: UnitOfWorkBuilder.Build(),
+                mapper: MapperBuilder.Build(),
+                updateRepository: new RecipeUpdateOnlyRepositoryBuilder().GetById(user, recipe).Build(),
+                cookingTimeReadOnlyRepository: repositoryCookingTime.Build(),
+                difficultyReadOnlyRepository: repositoryDifficulty.Build(),
+                dishTypeReadOnlyRepository: repositoryDishType.Build()
+                );
+        }
+    }
+}

--- a/tests/WebApi.test/Recipe/Update/UpdateRecipeTest.cs
+++ b/tests/WebApi.test/Recipe/Update/UpdateRecipeTest.cs
@@ -1,4 +1,5 @@
 ﻿using CommonTestUtilities.IdEncryption;
+using CommonTestUtilities.Requests;
 using CommonTestUtilities.Tokens;
 using MyRecipeBook.Exceptions.ExceptionsBase;
 using Shouldly;
@@ -6,19 +7,19 @@ using System.Net;
 using System.Text.Json;
 using WebApi.test.InlineData;
 
-namespace WebApi.test.Recipe.GetById
+namespace WebApi.test.Recipe.Update
 {
-    public class GetRecipeByIdTest : MyRecipeBookClassFixture
+    public class UpdateRecipeTest : MyRecipeBookClassFixture
     {
         private const string METHOD = "recipe";
-        
+
         private readonly Guid _userIdentifer;
         private readonly string _recipeId;
         private readonly string _recipeTitle;
 
         private readonly string _token;
 
-        public GetRecipeByIdTest(CustomWebApplicationFactory factory) : base(factory)
+        public UpdateRecipeTest(CustomWebApplicationFactory factory) : base(factory)
         {
             _userIdentifer = factory.GetUserIdentifier();
             _recipeId = factory.GetRecipeId();
@@ -29,27 +30,23 @@ namespace WebApi.test.Recipe.GetById
         [Fact]
         public async Task Success()
         {
-            var response = await DoGet(method: $"{METHOD}/{_recipeId}", token: _token);
+            var request = RequestRecipeJsonBuilder.Build();
 
-            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+            var response = await DoPut(method: $"{METHOD}/{_recipeId}", token: _token, request: request);
 
-            await using var responseBody = await response.Content.ReadAsStreamAsync();
-
-            var responseData = await JsonDocument.ParseAsync(responseBody);
-
-            responseData.RootElement.GetProperty("id").GetString().ShouldBe(_recipeId);
-            responseData.RootElement.GetProperty("title").GetString().ShouldBe(_recipeTitle);
+            response.StatusCode.ShouldBe(HttpStatusCode.NoContent);
         }
 
         [Theory]
         [ClassData(typeof(CultureInlineDataTest))]
-        public async Task Error_Recipe_Not_Found(string culture)
+        public async Task Error_Recipe_Title_Empty(string culture)
         {
-            var id = IdEncripterBuilder.Build().Encode(1000);
+            var request = RequestRecipeJsonBuilder.Build();
+            request.Title = string.Empty;
 
-            var response = await DoGet(method: $"{METHOD}/{id}", token: _token, culture: culture);
+            var response = await DoPut(method: $"{METHOD}/{_recipeId}", token: _token, culture: culture, request: request);
 
-            response.StatusCode.ShouldBe(HttpStatusCode.NotFound);
+            response.StatusCode.ShouldBe(HttpStatusCode.BadRequest);
 
             await using var responseBody = await response.Content.ReadAsStreamAsync();
 
@@ -57,13 +54,12 @@ namespace WebApi.test.Recipe.GetById
 
             var errors = responseData.RootElement.GetProperty("errors").EnumerateArray();
 
-            var expectedMessage = ResourceMessageHelper.FieldNotFound(fieldName: "Recipe");
+            var expectedMessage = ResourceMessageHelper.FieldEmpty(fieldName: "Title");
 
             errors.ShouldSatisfyAllConditions(
                e => e.ShouldHaveSingleItem(),
                e => e.Single().GetString()!.Equals(expectedMessage)
            );
         }
-
     }
 }


### PR DESCRIPTION
- Introduce `IRecipeUpdateOnlyRepository` and extend `RecipeRepository`
  * new `Update` method and non-tracking/full-tracking `GetById` helpers
  * private `GetFullRecipe()` to centralise eager loading
- Create `UpdateRecipeUseCase` with validation against cooking time, difficulty and dish-type repositories; maps and re-indexes instructions
- Wire everything up:
  * API: new `RecipeController.Update` action (`HttpPut /recipe/{id}`)
  * DI registrations in Infrastructure & Application layers
  * Test utilities (`RecipeUpdateOnlyRepositoryBuilder`) and thorough unit/integration tests (`UpdateRecipeUseCaseTest`, `UpdateRecipeTest`)
- Minor refactors:
  * rename parameters (`request` ➜ `recipeId`) for clarity
  * fix namespaces/usings and add `Microsoft.EntityFrameworkCore.Query`

Users can now update their own recipes while the system enforces the same business rules applied at creation time.