### PR TITLE
Add dashboard endpoint with recent-recipes feed and Swagger refinements

### DIFF
--- a/CommonTestUtilities/Repositories/RecipeReadOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/RecipeReadOnlyRepositoryBuilder.cs
@@ -25,6 +25,13 @@ namespace CommonTestUtilities.Repositories
             return this;
         }
 
+        public RecipeReadOnlyRepositoryBuilder GetForDashboard(User user, IList<Recipe> recipes)
+        {
+            _repository.Setup(repository => repository.GetForDashboard(user)).ReturnsAsync(recipes);
+
+            return this;
+        }
+
         public IRecipeReadOnlyRepository Build() => _repository.Object;
     }
 }

--- a/src/backend/MyRecipeBook.API/Controllers/DashboardController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/DashboardController.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using MyRecipeBook.API.Attributes;
+using MyRecipeBook.Application.UseCases.Dashboard.Get;
+using MyRecipeBook.Communication.Response;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace MyRecipeBook.API.Controllers
+{
+    [AuthenticatedUser]
+    public class DashboardController : MyRecipeBookBaseController
+    {
+        /// <summary>
+        /// Obtém os dados do dashboard do usuário
+        /// </summary>
+        /// <param name="useCase">Use case para obter dados do dashboard</param>
+        /// <returns>Lista das receitas mais recentes do usuário</returns>
+        /// <response code="200">Dados do dashboard obtidos com sucesso</response>
+        /// <response code="204">Usuário não possui receitas</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
+        [HttpGet]
+        [SwaggerOperation(
+            Summary = "Obtêm receitas",
+            Description = "Retorna as receitas mais recentes do usuário para exibição no dashboard",
+            OperationId = "GetDashboard"
+        )]
+        [ProducesResponseType(typeof(ResponseRecipesJson), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
+        public async Task<IActionResult> Get(
+            [FromServices] IGetDashboardUseCase useCase
+        )
+        {
+            var response = await useCase.Execute();
+
+            if (response.Recipes.Any())
+                return Ok(response);
+
+            return NoContent();
+        }
+    }
+}

--- a/src/backend/MyRecipeBook.API/Controllers/LoginController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/LoginController.cs
@@ -3,23 +3,36 @@ using MyRecipeBook.Application.UseCases.Login.DoLogin;
 using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Response;
 using MyRecipeBook.Communication.Responses;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace MyRecipeBook.API.Controllers
 {
-
+    [Tags("Authentication")]
     public class LoginController : MyRecipeBookBaseController
     {
+        /// <summary>
+        /// Realiza login do usuário
+        /// </summary>
+        /// <param name="useCase">Use case para fazer login</param>
+        /// <param name="request">Credenciais de login (email e senha)</param>
+        /// <returns>Dados do usuário autenticado e token de acesso</returns>
+        /// <response code="200">Login realizado com sucesso</response>
+        /// <response code="401">Email ou senha inválidos</response>
+        /// <response code="400">Dados de entrada inválidos</response>
         [HttpPost]
+        [SwaggerOperation(
+            Description = "Autentica um usuário no sistema usando email e senha",
+            OperationId = "LoginUser"
+        )]
         [ProducesResponseType(typeof(ResponseRegisteredUserJson), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
-        public async Task<IActionResult> Login
-            (
-                [FromServices] IDoLoginUseCase useCase,
-                [FromBody] RequestLoginJson request
-            )
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
+        public async Task<IActionResult> Login(
+            [FromServices] IDoLoginUseCase useCase,
+            [FromBody] RequestLoginJson request
+        )
         {
             var response = await useCase.Execute(request);
-
             return Ok(response);
         }
     }

--- a/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/RecipeController.cs
@@ -8,30 +8,59 @@ using MyRecipeBook.Application.UseCases.Recipe.Register;
 using MyRecipeBook.Application.UseCases.Recipe.Update;
 using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Response;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace MyRecipeBook.API.Controllers
-
 {
     [AuthenticatedUser]
+    [Tags("Recipes")]
     public class RecipeController : MyRecipeBookBaseController
     {
+        /// <summary>
+        /// Registra uma nova receita
+        /// </summary>
+        /// <param name="useCase">Use case para registro de receita</param>
+        /// <param name="request">Dados da receita a ser criada</param>
+        /// <returns>Dados da receita criada</returns>
+        /// <response code="201">Receita criada com sucesso</response>
+        /// <response code="400">Dados inválidos fornecidos</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
         [HttpPost]
+        [SwaggerOperation(
+            Summary = "Criar receitas",
+            Description = "Cria uma nova receita para o usuário autenticado",
+            OperationId = "CreateRecipe"
+        )]
         [ProducesResponseType(typeof(ResponseRegisteredRecipeJson), StatusCodes.Status201Created)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> Register(
             [FromServices] IRegisterRecipeUseCase useCase,
             [FromBody] RequestRecipeJson request
         )
         {
             var response = await useCase.Execute(request);
-
             return Created(string.Empty, response);
         }
 
-
+        /// <summary>
+        /// Filtra receitas baseado nos critérios fornecidos
+        /// </summary>
+        /// <param name="useCase">Use case para filtrar receitas</param>
+        /// <param name="request">Critérios de filtro</param>
+        /// <returns>Lista de receitas que atendem aos critérios</returns>
+        /// <response code="200">Receitas encontradas</response>
+        /// <response code="204">Nenhuma receita encontrada</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
         [HttpPost("filter")]
+        [SwaggerOperation(
+            Summary = "Filtrar receitas",
+            Description = "Filtra receitas do usuário baseado em critérios como dificuldade, tempo de preparo, etc.",
+            OperationId = "FilterRecipes"
+        )]
         [ProducesResponseType(typeof(ResponseRecipesJson), StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> Filter(
             [FromServices] IFilterRecipeUseCase useCase,
             [FromBody] RequestFilterRecipeJson request
@@ -45,24 +74,54 @@ namespace MyRecipeBook.API.Controllers
             return NoContent();
         }
 
-        [HttpGet]
-        [Route("{id}")]
+        /// <summary>
+        /// Obtém uma receita específica pelo ID
+        /// </summary>
+        /// <param name="useCase">Use case para obter receita</param>
+        /// <param name="id">ID criptografado da receita</param>
+        /// <returns>Dados completos da receita</returns>
+        /// <response code="200">Receita encontrada</response>
+        /// <response code="404">Receita não encontrada</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
+        [HttpGet("{id}")]
+        [SwaggerOperation(
+            Summary = "Obter receita por ID",
+            Description = "Retorna os detalhes completos de uma receita específica",
+            OperationId = "GetRecipeById"
+        )]
         [ProducesResponseType(typeof(ResponseRecipeJson), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> GetById(
             [FromServices] IGetRecipeByIdUseCase useCase,
             [FromRoute][ModelBinder(typeof(MyRecipeBookIdBinder))] long id
         )
         {
             var response = await useCase.Execute(id);
-
             return Ok(response);
         }
 
-        [HttpPut]
-        [Route("{id}")]
+        /// <summary>
+        /// Atualiza uma receita existente
+        /// </summary>
+        /// <param name="useCase">Use case para atualizar receita</param>
+        /// <param name="id">ID criptografado da receita</param>
+        /// <param name="request">Dados atualizados da receita</param>
+        /// <returns>Confirmação da atualização</returns>
+        /// <response code="204">Receita atualizada com sucesso</response>
+        /// <response code="400">Dados inválidos fornecidos</response>
+        /// <response code="404">Receita não encontrada</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
+        [HttpPut("{id}")]
+        [SwaggerOperation(
+            Summary = "Atualizar receita",
+            Description = "Atualiza todos os dados de uma receita existente",
+            OperationId = "UpdateRecipe"
+        )]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> Update(
             [FromServices] IUpdateRecipeUseCase useCase,
             [FromRoute][ModelBinder(typeof(MyRecipeBookIdBinder))] long id,
@@ -70,23 +129,34 @@ namespace MyRecipeBook.API.Controllers
         )
         {
             await useCase.Execute(id, request);
-
             return NoContent();
         }
 
-        [HttpDelete]
-        [Route("{id}")]
+        /// <summary>
+        /// Exclui uma receita
+        /// </summary>
+        /// <param name="useCase">Use case para excluir receita</param>
+        /// <param name="id">ID criptografado da receita</param>
+        /// <returns>Confirmação da exclusão</returns>
+        /// <response code="204">Receita excluída com sucesso</response>
+        /// <response code="404">Receita não encontrada</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
+        [HttpDelete("{id}")]
+        [SwaggerOperation(
+            Summary = "Excluir receita",
+            Description = "Remove permanentemente uma receita do sistema",
+            OperationId = "DeleteRecipe"
+        )]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status404NotFound)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         public async Task<IActionResult> Delete(
             [FromServices] IDeleteRecipeUseCase useCase,
             [FromRoute][ModelBinder(typeof(MyRecipeBookIdBinder))] long id
         )
         {
             await useCase.Execute(id);
-
             return NoContent();
         }
     }
-
 }

--- a/src/backend/MyRecipeBook.API/Controllers/UserController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/UserController.cs
@@ -8,56 +8,110 @@ using MyRecipeBook.Communication.Request;
 using MyRecipeBook.Communication.Requests;
 using MyRecipeBook.Communication.Response;
 using MyRecipeBook.Communication.Responses;
+using Swashbuckle.AspNetCore.Annotations;
 
 namespace MyRecipeBook.API.Controllers
 {
-
+    [Tags("Users")]
     public class UserController : MyRecipeBookBaseController
     {
+        /// <summary>
+        /// Registra um novo usuário no sistema
+        /// </summary>
+        /// <param name="useCase">Use case para registro de usuário</param>
+        /// <param name="request">Dados do usuário a ser registrado</param>
+        /// <returns>Dados do usuário criado e token de acesso</returns>
+        /// <response code="201">Usuário criado com sucesso</response>
+        /// <response code="400">Dados inválidos ou email já cadastrado</response>
         [HttpPost]
+        [SwaggerOperation(
+            Summary = "Criar usuário",
+            Description = "Cria uma nova conta de usuário no sistema",
+            OperationId = "RegisterUser"
+        )]
         [ProducesResponseType(typeof(ResponseRegisteredUserJson), StatusCodes.Status201Created)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
         public async Task<IActionResult> Register(
             [FromServices] IRegisterUserUseCase useCase,
             [FromBody] RequestRegisterUserJson request)
         {
             var result = await useCase.Execute(request);
-
             return Created(string.Empty, result);
         }
 
+        /// <summary>
+        /// Obtém o perfil do usuário autenticado
+        /// </summary>
+        /// <param name="useCase">Use case para obter perfil</param>
+        /// <returns>Dados do perfil do usuário</returns>
+        /// <response code="200">Perfil do usuário obtido com sucesso</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
         [HttpGet]
+        [SwaggerOperation(
+            Summary = "Obter perfil do usuário",
+            Description = "Retorna as informações do perfil do usuário autenticado",
+            OperationId = "GetUserProfile"
+        )]
         [ProducesResponseType(typeof(ResponseUserProfileJson), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         [AuthenticatedUser]
         public async Task<IActionResult> GetUserProfile([FromServices] IGetUserProfileUseCase useCase)
         {
             var result = await useCase.Execute();
-
             return Ok(result);
         }
 
+        /// <summary>
+        /// Atualiza os dados do usuário autenticado
+        /// </summary>
+        /// <param name="useCase">Use case para atualizar usuário</param>
+        /// <param name="request">Dados atualizados do usuário</param>
+        /// <returns>Confirmação da atualização</returns>
+        /// <response code="204">Usuário atualizado com sucesso</response>
+        /// <response code="400">Dados inválidos fornecidos</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
         [HttpPut]
+        [SwaggerOperation(
+            Summary = "Atualizar perfil do usuário",
+            Description = "Atualiza as informações do perfil do usuário autenticado",
+            OperationId = "UpdateUser"
+        )]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         [AuthenticatedUser]
         public async Task<IActionResult> Update(
             [FromServices] IUpdateUserUseCase useCase,
             [FromBody] RequestUpdateUserJson request)
         {
             await useCase.Execute(request);
-
             return NoContent();
         }
 
+        /// <summary>
+        /// Altera a senha do usuário autenticado
+        /// </summary>
+        /// <param name="useCase">Use case para alterar senha</param>
+        /// <param name="request">Dados para alteração de senha (senha atual e nova senha)</param>
+        /// <returns>Confirmação da alteração</returns>
+        /// <response code="204">Senha alterada com sucesso</response>
+        /// <response code="400">Dados inválidos ou senha atual incorreta</response>
+        /// <response code="401">Token de autenticação inválido ou ausente</response>
         [HttpPut("change-password")]
+        [SwaggerOperation(
+            Summary = "Alterar senha",
+            Description = "Altera a senha do usuário autenticado",
+            OperationId = "ChangePassword"
+        )]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
         [AuthenticatedUser]
         public async Task<IActionResult> ChangePassword(
             [FromServices] IChangePasswordUseCase useCase,
             [FromBody] RequestChangePasswordJson request)
         {
             await useCase.Execute(request);
-
             return NoContent();
         }
     }

--- a/src/backend/MyRecipeBook.API/Filters/TagOrdererFilter.cs
+++ b/src/backend/MyRecipeBook.API/Filters/TagOrdererFilter.cs
@@ -1,0 +1,22 @@
+﻿// MyRecipeBook.API/Filters/TagOrdererFilter.cs
+
+using Microsoft.OpenApi.Models;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace MyRecipeBook.API.Filters
+{
+    public sealed class TagOrdererFilter : IDocumentFilter
+    {
+        public void Apply(OpenApiDocument swaggerDoc, DocumentFilterContext context)
+        {
+
+            swaggerDoc.Tags = new List<OpenApiTag>
+            {
+                new() { Name = "Authentication"},
+                new() { Name = "Users"},
+                new() { Name = "Recipes"},
+                new() { Name = "Dashboard"}
+            };
+        }
+    }
+}

--- a/src/backend/MyRecipeBook.API/MyRecipeBook.API.csproj
+++ b/src/backend/MyRecipeBook.API/MyRecipeBook.API.csproj
@@ -11,11 +11,12 @@
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
-    <PackageReference Include="Scalar.AspNetCore" Version="2.4.13" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="8.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="8.1.4" />
+    <PackageReference Include="Scalar.AspNetCore" Version="2.6.8" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="9.0.3" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="9.0.3" />
+	<PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.3" />
+	<PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="9.0.3" />
     
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="8.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -12,6 +12,7 @@ using MyRecipeBook.Infrastructure;
 using MyRecipeBook.Infrastructure.Extensions;
 using MyRecipeBook.Infrastructure.Migrations;
 using Scalar.AspNetCore;
+using System.Reflection;
 
 
 var builder = WebApplication.CreateBuilder(args);
@@ -27,6 +28,36 @@ builder.Services.AddSwaggerGen(c =>
     c.SupportNonNullableReferenceTypes();
     c.UseAllOfToExtendReferenceSchemas();
 
+    c.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "My Recipe Book API",
+        Version = "v1.0.0",
+        Description = "API completa para gerenciamento de receitas culinárias. " +
+                     "Permite criar, editar, listar e excluir receitas, além de gerenciar usuários e autenticação.",
+        Contact = new OpenApiContact
+        {
+            Name = "My Recipe Book Team",
+            Email = "support@myrecipebook.com",
+            Url = new Uri("https://github.com/yourrepo/myrecipebook")
+        },
+        License = new OpenApiLicense
+        {
+            Name = "MIT License",
+            Url = new Uri("https://opensource.org/licenses/MIT")
+        },
+        TermsOfService = new Uri("https://myrecipebook.com/terms")
+    });
+
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    if (File.Exists(xmlPath))
+    {
+        c.IncludeXmlComments(xmlPath);
+    }
+
+    c.EnableAnnotations();
+    c.DocumentFilter<TagOrdererFilter>();
+
     c.OperationFilter<IdsFilter>();
 
     c.AddSecurityDefinition(_bearer, new OpenApiSecurityScheme()
@@ -40,6 +71,33 @@ builder.Services.AddSwaggerGen(c =>
         "Example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...'",
 
     });
+
+    c.OrderActionsBy(api =>
+    {
+        var controllerOrder = new Dictionary<string, int>
+        {
+            ["User"] = 1,
+            ["Login"] = 2,
+            ["Dashboard"] = 3,
+            ["Recipes"] = 4
+        };
+
+        var ctrl = api.ActionDescriptor.RouteValues["controller"] ?? "";
+        var grp = controllerOrder.TryGetValue(ctrl, out var g) ? g : 99;
+
+        var method = api.HttpMethod?.ToUpperInvariant() switch
+        {
+            "GET" => 1,
+            "POST" => 2,
+            "PUT" => 3,
+            "DELETE" => 4,
+            _ => 9
+        };
+
+        // 01_01_/user/{id}
+        return $"{grp:D2}_{method:D2}_{api.RelativePath}";
+    });
+
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
                 {
                     {
@@ -92,16 +150,15 @@ if (app.Environment.IsDevelopment())
 
     app.MapScalarApiReference(options =>
     {
-        options.WithTheme(ScalarTheme.BluePlanet);
-
-        options.WithDarkModeToggle(true);           
-        options.WithSidebar(true);                 
-        options.WithModels(false);               
-        
-        options.WithTitle("My Recipe Book")
-               .WithSidebar(true);
-        options.AddPreferredSecuritySchemes(_bearer);
-
+        options.WithTheme(ScalarTheme.BluePlanet)
+            .WithDarkModeToggle(true)
+            .WithSidebar(true)     
+            .WithModels(true)
+            .WithTitle("My Recipe Book")
+            .AddPreferredSecuritySchemes(_bearer)
+         
+            .WithTagSorter(TagSorter.Alpha)
+            .WithOperationSorter(OperationSorter.Method);
     });
 
     app.UseSwagger();      

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -19,6 +19,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 const string _bearer = "Bearer";
 
+const string _gitHubUrl = "https://github.com/lluan4/my-recipe-book";
+const string _mitLicense = "https://opensource.org/licenses/MIT";
+
 
 builder.Services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new StringConverter()));
 
@@ -36,16 +39,14 @@ builder.Services.AddSwaggerGen(c =>
                      "Permite criar, editar, listar e excluir receitas, além de gerenciar usuários e autenticação.",
         Contact = new OpenApiContact
         {
-            Name = "My Recipe Book Team",
-            Email = "support@myrecipebook.com",
-            Url = new Uri("https://github.com/yourrepo/myrecipebook")
+            Name = "Luan Lima",
+            Url = new Uri(_gitHubUrl)
         },
         License = new OpenApiLicense
         {
             Name = "MIT License",
-            Url = new Uri("https://opensource.org/licenses/MIT")
+            Url = new Uri(_mitLicense)
         },
-        TermsOfService = new Uri("https://myrecipebook.com/terms")
     });
 
     var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -19,8 +19,13 @@ var builder = WebApplication.CreateBuilder(args);
 
 const string _bearer = "Bearer";
 
-const string _gitHubUrl = "https://github.com/lluan4/my-recipe-book";
-const string _mitLicense = "https://opensource.org/licenses/MIT";
+var configuration = builder.Configuration;
+
+var gitHubUrl = configuration.GetValue<string>("Settings:OpenApi:GitHubUrl")!;
+var mitLicenseUrl = configuration.GetValue<string>("Settings:OpenApi:MitLicenseUrl")!;
+var contactName = configuration.GetValue<string>("Settings:OpenApi:ContactName")!;
+var licenseName = configuration.GetValue<string>("Settings:OpenApi:LicenseName")!;
+
 
 
 builder.Services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new StringConverter()));
@@ -39,13 +44,13 @@ builder.Services.AddSwaggerGen(c =>
                      "Permite criar, editar, listar e excluir receitas, além de gerenciar usuários e autenticação.",
         Contact = new OpenApiContact
         {
-            Name = "Luan Lima",
-            Url = new Uri(_gitHubUrl)
+            Name = contactName,
+            Url = new Uri(gitHubUrl)
         },
         License = new OpenApiLicense
         {
-            Name = "MIT License",
-            Url = new Uri(_mitLicense)
+            Name = licenseName,
+            Url = new Uri(mitLicenseUrl)
         },
     });
 

--- a/src/backend/MyRecipeBook.API/appsettings.Development.json
+++ b/src/backend/MyRecipeBook.API/appsettings.Development.json
@@ -10,6 +10,12 @@
       "ExpirationTimeMinutes": 1000,
       "SigningKey": "qweqweqweqweqweqweqweqweqweqweqw"
     },
-    "IdCryptographyAlphabet": "rOvmjkATPy2xsp8WbouJKBZw9Q1ftVNCYSgDi5GqH4hlacIU7FnEeMdRzX63L0"
+    "IdCryptographyAlphabet": "rOvmjkATPy2xsp8WbouJKBZw9Q1ftVNCYSgDi5GqH4hlacIU7FnEeMdRzX63L0",
+    "OpenApi": {
+      "GitHubUrl": "https://github.com/lluan4/my-recipe-book",
+      "MitLicenseUrl": "https://opensource.org/licenses/MIT",
+      "ContactName": "Luan Lima",
+      "LicenseName": "MIT License"
+    }
   }
 }

--- a/src/backend/MyRecipeBook.API/appsettings.Test.json
+++ b/src/backend/MyRecipeBook.API/appsettings.Test.json
@@ -8,6 +8,12 @@
       "ExpirationTimeMinutes": 1000,
       "SigningKey": "qweqweqweqweqweqweqweqweqweqweqw"
     },
-    "IdCryptographyAlphabet": "rOvmjkATPy2xsp8WbouJKBZw9Q1ftVNCYSgDi5GqH4hlacIU7FnEeMdRzX63L0"
+    "IdCryptographyAlphabet": "rOvmjkATPy2xsp8WbouJKBZw9Q1ftVNCYSgDi5GqH4hlacIU7FnEeMdRzX63L0",
+    "OpenApi": {
+      "GitHubUrl": "https://github.com/lluan4/my-recipe-book",
+      "MitLicenseUrl": "https://opensource.org/licenses/MIT",
+      "ContactName": "Luan Lima",
+      "LicenseName": "MIT License"
+    }
   }
 }

--- a/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/Recipe/IRecipeReadOnlyRepository.cs
@@ -6,5 +6,6 @@ namespace MyRecipeBook.Domain.Repositories.Recipe
     {
         Task<IList<Entities.Recipe>> Filter(Entities.User user, FilterRecipesDto filters);
         Task<Entities.Recipe?> GetById(Entities.User user, long recipeId);
+        Task<IList<Entities.Recipe>> GetForDashboard(Entities.User user);
     }
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/RecipeRepository.cs
@@ -24,11 +24,7 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 
         public async Task<IList<Recipe>> Filter(User user, FilterRecipesDto filters)
         {
-            var query = _dbContext
-                 .Recipes
-                 .AsNoTracking()
-                 .Include(recipe => recipe.Ingredients)
-                 .Where(recipe => recipe.Active && recipe.UserId == user.Id);
+            var query = GetBaseRecipe(user: user);
 
             if (filters.Difficulties.Any())
             {
@@ -54,6 +50,14 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
             return await query.ToListAsync();
         }
 
+        public async Task<IList<Recipe>> GetForDashboard(User user)
+        {
+            return await GetBaseRecipe(user: user)
+                .OrderByDescending(recipe => recipe.CreatedOn)
+                .Take(5)
+                .ToListAsync();
+        }
+
         async Task<Recipe?> IRecipeReadOnlyRepository.GetById(User user, long recipeId)
         {
             return await GetFullRecipe()
@@ -62,7 +66,7 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
                                           r.UserId == user.Id &&
                                           r.Active);
         }
-
+       
         async Task<Recipe?> IRecipeUpdateOnlyRepository.GetById(User user, long recipeId) 
         {
             return await GetFullRecipe()
@@ -70,8 +74,9 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
                                         r.UserId == user.Id &&
                                         r.Active);
         }
+       
         public void Update(Recipe recipe) => _dbContext.Recipes.Update(recipe);
-
+       
         private IIncludableQueryable<Recipe, IList<Instruction>> GetFullRecipe()
         {
             return _dbContext
@@ -82,6 +87,15 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
                     .ThenInclude(rd => rd.DishType)
                 .Include(r => r.Ingredients)
                 .Include(r => r.Instructions);
+        }
+
+        private IQueryable<Recipe> GetBaseRecipe(User user)
+        {
+            return _dbContext
+                .Recipes
+                .AsNoTracking()
+                .Include(recipe => recipe.Ingredients)
+                .Where(recipe => recipe.Active && recipe.UserId == user.Id);   
         }
 
     }

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MyRecipeBook.Application.Services.AutoMapper;
+using MyRecipeBook.Application.UseCases.Dashboard.Get;
 using MyRecipeBook.Application.UseCases.Login.DoLogin;
 using MyRecipeBook.Application.UseCases.Recipe.Delete;
 using MyRecipeBook.Application.UseCases.Recipe.Filter;
@@ -65,6 +66,9 @@ namespace MyRecipeBook.Application
             services.AddScoped<IGetRecipeByIdUseCase, GetRecipeByIdUseCase>();
             services.AddScoped<IUpdateRecipeUseCase, UpdateRecipeUseCase>();
             services.AddScoped<IDeleteRecipeUseCase, DeleteRecipeUseCase>();
+
+            services.AddScoped<IGetDashboardUseCase, GetDashboardUseCase>();
+
         }
 
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Dashboard/Get/GetDashboardUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Dashboard/Get/GetDashboardUseCase.cs
@@ -1,0 +1,33 @@
+﻿using AutoMapper;
+using MyRecipeBook.Communication.Response;
+using MyRecipeBook.Domain.Repositories.Recipe;
+using MyRecipeBook.Domain.Services.LoggedUser;
+
+namespace MyRecipeBook.Application.UseCases.Dashboard.Get
+{
+    public class GetDashboardUseCase : IGetDashboardUseCase
+    {
+        private readonly IRecipeReadOnlyRepository _recipeReadOnlyRepository;
+        private readonly IMapper _mapper;
+        private readonly ILoggedUser _loggedUser;
+
+        public GetDashboardUseCase(IRecipeReadOnlyRepository recipeReadOnlyRepository, IMapper mapper, ILoggedUser loggedUser)
+        {
+            _recipeReadOnlyRepository = recipeReadOnlyRepository;
+            _mapper = mapper;
+            _loggedUser = loggedUser;
+        }
+
+        public async Task<ResponseRecipesJson> Execute()
+        {
+            var loggedUser = await _loggedUser.User();
+
+            var recipes = await _recipeReadOnlyRepository.GetForDashboard(user: loggedUser);
+
+            return new ResponseRecipesJson
+            {
+                Recipes = _mapper.Map<IList<ResponseShortRecipeJson>>(recipes)
+            };
+        }
+    }
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Dashboard/Get/IGetDashboardUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Dashboard/Get/IGetDashboardUseCase.cs
@@ -1,0 +1,9 @@
+﻿using MyRecipeBook.Communication.Response;
+
+namespace MyRecipeBook.Application.UseCases.Dashboard.Get
+{
+    public interface IGetDashboardUseCase
+    {
+        Task<ResponseRecipesJson> Execute();
+    }
+}

--- a/tests/UseCases.Test/Dashboard/GetDashboardUseCaseTest.cs
+++ b/tests/UseCases.Test/Dashboard/GetDashboardUseCaseTest.cs
@@ -1,0 +1,52 @@
+﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.LoggedUser;
+using CommonTestUtilities.Mapper;
+using CommonTestUtilities.Repositories;
+using MyRecipeBook.Application.UseCases.Dashboard.Get;
+using Shouldly;
+
+namespace UseCases.Test.Dashboard
+{
+    public class GetDashboardUseCaseTest
+    {
+
+        [Fact]
+        public async Task Success()
+        {
+            (var user, _) = UserBuilder.Build();
+
+            var recipes = RecipeBuilder.Collection(user);
+
+            var useCase = CreateUseCase(user, recipes);
+
+            var result = await useCase.Execute();
+
+            result.Recipes.ShouldSatisfyAllConditions(
+                () => recipes.ShouldNotBeEmpty(),
+                () => recipes.Select(r => r.Id).ShouldBeUnique()
+            );
+
+            foreach (var recipe in result.Recipes)
+            {
+                recipe.ShouldSatisfyAllConditions(
+                    () => recipe.Id.ShouldNotBeNullOrWhiteSpace(),
+                    () => recipe.Title.ShouldNotBeNullOrWhiteSpace(),
+                    () => recipe.AmountIngredients.ShouldBeGreaterThan(0)
+                );
+            }
+
+        }
+
+        private static GetDashboardUseCase CreateUseCase(
+            MyRecipeBook.Domain.Entities.User user,
+            IList<MyRecipeBook.Domain.Entities.Recipe> recipes
+            )
+        {
+            var mapper = MapperBuilder.Build();
+            var loggedUser = LoggedUserBuilder.Build(user);
+            var repository = new RecipeReadOnlyRepositoryBuilder().GetForDashboard(user, recipes).Build();
+
+            return new GetDashboardUseCase(recipeReadOnlyRepository: repository, mapper: mapper, loggedUser: loggedUser);
+        }
+    }
+}

--- a/tests/WebApi.test/Dashboard/GetDashboardInvalidTokenTest.cs
+++ b/tests/WebApi.test/Dashboard/GetDashboardInvalidTokenTest.cs
@@ -1,0 +1,43 @@
+﻿using CommonTestUtilities.Requests;
+using CommonTestUtilities.Tokens;
+using Shouldly;
+using System.Net;
+
+namespace WebApi.test.Dashboard
+{
+    public class GetDashboardInvalidTokenTest : MyRecipeBookClassFixture
+    {
+        private const string METHOD = "dashboard";
+        private const string INVALID_TOKEN = "123";
+
+        public GetDashboardInvalidTokenTest(CustomWebApplicationFactory factory) : base(factory)
+        {
+        }
+
+        [Fact]
+        public async Task Error_Invalid_Token()
+        {
+            var response = await DoGet(method: METHOD, token: INVALID_TOKEN);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task Error_Without_Token()
+        {
+            var response = await DoGet(method: METHOD,  token: string.Empty);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+
+        [Fact]
+        public async Task Error_Token_With_User_NotFound()
+        {
+            var token = JwtTokensGeneratorBuilder.Build().Generate(Guid.NewGuid());
+
+            var response = await DoGet(method: METHOD, token: token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.Unauthorized);
+        }
+    }
+}

--- a/tests/WebApi.test/Dashboard/GetDashboardTest.cs
+++ b/tests/WebApi.test/Dashboard/GetDashboardTest.cs
@@ -1,0 +1,35 @@
+﻿using CommonTestUtilities.Tokens;
+using Shouldly;
+using System.Net;
+using System.Text.Json;
+
+namespace WebApi.test.Dashboard
+{
+    public class GetDashboardTest : MyRecipeBookClassFixture
+    {
+        private const string METHOD = "dashboard";
+
+        private readonly Guid _userIdentifier;
+
+        public GetDashboardTest(CustomWebApplicationFactory factory) : base(factory)
+        {
+            _userIdentifier = factory.GetUserIdentifier();
+        }
+
+        [Fact]
+        public async Task Success()
+        {
+            var token = JwtTokensGeneratorBuilder.Build().Generate(_userIdentifier);
+
+            var response = await DoGet(method: METHOD, token: token);
+
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+
+            await using var responseBody = await response.Content.ReadAsStreamAsync();
+
+            var responseData = await JsonDocument.ParseAsync(responseBody);
+
+            responseData.RootElement.GetProperty("recipes").GetArrayLength().ShouldBeGreaterThan(0);
+        }
+    }
+}

--- a/tests/WebApi.test/Recipe/Filter/FilterRecipeTest.cs
+++ b/tests/WebApi.test/Recipe/Filter/FilterRecipeTest.cs
@@ -14,7 +14,6 @@ namespace WebApi.test.Recipe.Filter
     public class FilterRecipeTest : MyRecipeBookClassFixture
     {
         private const string METHOD = "recipe/filter";
-        private const string INVALID_TOKEN = "123";
 
         private readonly Guid _userIdentifier;
 


### PR DESCRIPTION
* Introduce `DashboardController` (`GET /dashboard`) that returns the authenticated user’s five most-recent recipes, responding 204 when none.
* Create `GetDashboardUseCase`, register it in DI, and expose `IRecipeReadOnlyRepository.GetForDashboard` plus helper `GetBaseRecipe`.
* Refactor filter logic to reuse `GetBaseRecipe` for consistency.
* Upgrade Swashbuckle & Scalar packages; enable annotations, custom tag ordering (`TagOrdererFilter`) and operation sorting; enrich API metadata.
* Decorate existing controllers with `[Tags]`, summaries and extra `ProducesResponseType`s to generate richer OpenAPI output.
* Add builder support in tests and comprehensive unit & integration tests covering success, invalid token and user-not-found scenarios.

These changes deliver a performant dashboard feed while making the REST surface self-documenting and easier to navigate.