### PR TITLE
Implement async user account deletion via Service Bus

### DIFF
--- a/CommonTestUtilities/Repositories/UserDeleteOnlyRepositoryBuilder.cs
+++ b/CommonTestUtilities/Repositories/UserDeleteOnlyRepositoryBuilder.cs
@@ -1,0 +1,16 @@
+﻿using Moq;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Repositories.User;
+
+namespace CommonTestUtilities.Repositories
+{
+	public class UserDeleteOnlyRepositoryBuilder
+	{
+		private readonly Mock<IUserDeleteOnlyRepository> _repository;
+
+		public UserDeleteOnlyRepositoryBuilder() => _repository = new Mock<IUserDeleteOnlyRepository>();
+
+		public IUserDeleteOnlyRepository Build() => _repository.Object;
+
+	}
+}

--- a/CommonTestUtilities/ServiceBus/DeleteUserQueueBuilder.cs
+++ b/CommonTestUtilities/ServiceBus/DeleteUserQueueBuilder.cs
@@ -1,0 +1,13 @@
+﻿using Moq;
+using MyRecipeBook.Domain.Services.ServiceBus;
+
+namespace CommonTestUtilities.ServiceBus
+{
+	public class DeleteUserQueueBuilder
+	{
+		public static IDeleteUserQueue Build()
+		{
+			return new Mock<IDeleteUserQueue>().Object;
+		}
+	}
+}

--- a/src/backend/MyRecipeBook.API/BackgroundServices/DeleteUserService.cs
+++ b/src/backend/MyRecipeBook.API/BackgroundServices/DeleteUserService.cs
@@ -1,5 +1,4 @@
-﻿
-using Azure.Messaging.ServiceBus;
+﻿using Azure.Messaging.ServiceBus;
 using MyRecipeBook.Application.UseCases.User.Delete;
 
 namespace MyRecipeBook.API.BackgroundServices
@@ -36,7 +35,7 @@ namespace MyRecipeBook.API.BackgroundServices
 
 			await deleteUserUseCase.Execute(userIdentifier);
 		}
-		private Task ExceptionReceivedHandler(ProcessErrorEventArgs _) => Task.CompletedTask;
+		private static Task ExceptionReceivedHandler(ProcessErrorEventArgs _) => Task.CompletedTask;
 
 		~DeleteUserService() => Dispose();
 

--- a/src/backend/MyRecipeBook.API/BackgroundServices/DeleteUserService.cs
+++ b/src/backend/MyRecipeBook.API/BackgroundServices/DeleteUserService.cs
@@ -1,0 +1,50 @@
+﻿
+using Azure.Messaging.ServiceBus;
+using MyRecipeBook.Application.UseCases.User.Delete;
+
+namespace MyRecipeBook.API.BackgroundServices
+{
+	public class DeleteUserService:BackgroundService
+	{
+		private readonly IServiceProvider _services;
+		private readonly ServiceBusProcessor _processor;
+
+		public DeleteUserService(IServiceProvider services, ServiceBusProcessor processor)
+		{
+			_services = services;
+			_processor = processor;
+		}
+
+		protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+		{
+			_processor.ProcessMessageAsync += ProcessMessageAsync;
+
+			_processor.ProcessErrorAsync += ExceptionReceivedHandler;
+
+			await _processor.StartProcessingAsync(stoppingToken);
+		}
+
+		private async Task ProcessMessageAsync(ProcessMessageEventArgs eventArgs)
+		{
+			var message = eventArgs.Message.Body.ToString();
+
+			var userIdentifier = Guid.Parse(message);
+
+			var scope = _services.CreateScope();
+
+			var deleteUserUseCase = scope.ServiceProvider.GetRequiredService<IDeleteUserAccountUseCase>();
+
+			await deleteUserUseCase.Execute(userIdentifier);
+		}
+		private Task ExceptionReceivedHandler(ProcessErrorEventArgs _) => Task.CompletedTask;
+
+		~DeleteUserService() => Dispose();
+
+		public override void Dispose()
+		{
+			base.Dispose();
+
+			GC.SuppressFinalize(this);
+		}
+	}
+}

--- a/src/backend/MyRecipeBook.API/Controllers/UserController.cs
+++ b/src/backend/MyRecipeBook.API/Controllers/UserController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using MyRecipeBook.API.Attributes;
 using MyRecipeBook.Application.UseCases.User.ChangePassword;
+using MyRecipeBook.Application.UseCases.User.Delete.Request;
 using MyRecipeBook.Application.UseCases.User.Profile;
 using MyRecipeBook.Application.UseCases.User.Register;
 using MyRecipeBook.Application.UseCases.User.Update;
@@ -83,6 +84,24 @@ namespace MyRecipeBook.API.Controllers
             [FromBody] RequestChangePasswordJson request)
         {
             await useCase.Execute(request);
+            return NoContent();
+        }
+
+        [HttpDelete]
+        [SwaggerOperation(
+            Summary = "Deletar Conta",
+            Description = "Deleta conta do usuário",
+            OperationId = "DeleteAccount"
+        )]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(typeof(ResponseErrorJson), StatusCodes.Status401Unauthorized)]
+        [AuthenticatedUser]
+        public async Task<IActionResult> Delete(
+            [FromServices] IDeleteUserUseCase useCase)
+        {
+            await useCase.Execute();
+
             return NoContent();
         }
     }

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
+using MyRecipeBook.API.BackgroundServices;
 using MyRecipeBook.API.Converters;
 using MyRecipeBook.API.Filters;
 using MyRecipeBook.API.Middleware;
@@ -119,8 +120,10 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 		 options.TokenValidationParameters = new TokenValidationParameters { };
 	 });
 
+builder.Services.AddHostedService<DeleteUserService>();
 
 var app = builder.Build();
+
 
 
 if(app.Environment.IsDevelopment())

--- a/src/backend/MyRecipeBook.API/Program.cs
+++ b/src/backend/MyRecipeBook.API/Program.cs
@@ -26,6 +26,7 @@ var gitHubUrl = configuration.GetValue<string>("Settings:OpenApi:GitHubUrl")!;
 var mitLicenseUrl = configuration.GetValue<string>("Settings:OpenApi:MitLicenseUrl")!;
 var contactName = configuration.GetValue<string>("Settings:OpenApi:ContactName")!;
 var licenseName = configuration.GetValue<string>("Settings:OpenApi:LicenseName")!;
+var serviceBusConnectionString = configuration.GetValue<string>("Settings:ServiceBus:DeleteUserAccount");
 
 
 
@@ -120,7 +121,10 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 		 options.TokenValidationParameters = new TokenValidationParameters { };
 	 });
 
-builder.Services.AddHostedService<DeleteUserService>();
+if(!string.IsNullOrWhiteSpace(serviceBusConnectionString))
+{
+	builder.Services.AddHostedService<DeleteUserService>();
+}
 
 var app = builder.Build();
 

--- a/src/backend/MyRecipeBook.Domain/Repositories/User/IUserDeleteOnlyRepository.cs
+++ b/src/backend/MyRecipeBook.Domain/Repositories/User/IUserDeleteOnlyRepository.cs
@@ -1,0 +1,7 @@
+﻿namespace MyRecipeBook.Domain.Repositories.User
+{
+	public interface IUserDeleteOnlyRepository
+	{
+		Task DeleteAccount(Guid userIdentifier);
+	}
+}

--- a/src/backend/MyRecipeBook.Domain/Services/ServiceBus/IDeleteUserQueue.cs
+++ b/src/backend/MyRecipeBook.Domain/Services/ServiceBus/IDeleteUserQueue.cs
@@ -1,0 +1,9 @@
+﻿using MyRecipeBook.Domain.Entities;
+
+namespace MyRecipeBook.Domain.Services.ServiceBus
+{
+	public interface IDeleteUserQueue
+	{
+		Task SendMessage(User user);
+	}
+}

--- a/src/backend/MyRecipeBook.Domain/Services/Storage/IBlobStorageService.cs
+++ b/src/backend/MyRecipeBook.Domain/Services/Storage/IBlobStorageService.cs
@@ -7,5 +7,6 @@ namespace MyRecipeBook.Domain.Services.Storage
 		Task Upload(User user, Stream file, string fileName);
 		Task<string> GetFileUrl(User user, string imageIdentifier);
 		Task Delete(User user, string imageIdentifier);
+		Task DeleteContainer(Guid userIdentifier);
 	}
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/UserRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/UserRepository.cs
@@ -4,47 +4,66 @@ using MyRecipeBook.Domain.Repositories.User;
 
 namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 {
-    public class UserRepository : IUserWriteOnlyRepository, IUserReadOnlyRepository, IUserUpdateOnlyRepository
-    {
-        private readonly MyRecipeBookDbContext _dbContext;
+	public class UserRepository:IUserWriteOnlyRepository, IUserReadOnlyRepository, IUserUpdateOnlyRepository, IUserDeleteOnlyRepository
+	{
+		private readonly MyRecipeBookDbContext _dbContext;
 
-        public UserRepository(MyRecipeBookDbContext dbContext) => _dbContext = dbContext;
+		public UserRepository(MyRecipeBookDbContext dbContext) => _dbContext = dbContext;
 
 
-        public async Task Add(User user) => await _dbContext.Users.AddAsync(user);
+		public async Task Add(User user) => await _dbContext.Users.AddAsync(user);
 
-        public async Task<bool> ExistActiveUserWithEmail(string email) =>
-            await _dbContext.Users.AnyAsync(user => user.Email.Equals(email) && user.Active);
+		public async Task<bool> ExistActiveUserWithEmail(string email) =>
+			 await _dbContext.Users.AnyAsync(user => user.Email.Equals(email) && user.Active);
 
-        public async Task<User?> GetByEmailAndPassword(string email, string password)
-        {
-            return await _dbContext
-                .Users
-                .AsNoTracking()
-                .FirstOrDefaultAsync(user => user.Active && user.Email.Equals(email) && user.Password.Equals(password));
-        }
+		public async Task<User?> GetByEmailAndPassword(string email, string password)
+		{
+			return await _dbContext
+				 .Users
+				 .AsNoTracking()
+				 .FirstOrDefaultAsync(user => user.Active && user.Email.Equals(email) && user.Password.Equals(password));
+		}
 
-        public async Task<bool> ExistActiveUserWithIdentifier(Guid userIdentifier)
-        {
-            return await _dbContext
-                .Users
-                .AnyAsync(user => user.UserIdentifier.Equals(userIdentifier) && user.Active);
-        }
+		public async Task<bool> ExistActiveUserWithIdentifier(Guid userIdentifier)
+		{
+			return await _dbContext
+				 .Users
+				 .AnyAsync(user => user.UserIdentifier.Equals(userIdentifier) && user.Active);
+		}
 
-        public async Task<User> GetByUserIdentifier(Guid userIdentifier)
-        {
-            return await _dbContext
-                 .Users
-                 .AsNoTracking()
-                 .FirstAsync(user => user.Active && user.UserIdentifier.Equals(userIdentifier));
-        }
-        public async Task<User> GetById(long id)
-        {
-            return await _dbContext
-               .Users
-               .FirstAsync(user => user.Id == id);
-        }
-        public void Update(User user) => _dbContext.Users.Update(user);
+		public async Task<User> GetByUserIdentifier(Guid userIdentifier)
+		{
+			return await _dbContext
+				  .Users
+				  .AsNoTracking()
+				  .FirstAsync(user => user.Active && user.UserIdentifier.Equals(userIdentifier));
+		}
+		public async Task<User> GetById(long id)
+		{
+			return await _dbContext
+				.Users
+				.FirstAsync(user => user.Id == id);
+		}
+		public void Update(User user) => _dbContext.Users.Update(user);
 
-    }
+		public async Task DeleteAccount(Guid userIdentifier)
+		{
+			var user = await _dbContext.Users.FirstOrDefaultAsync(u => u.UserIdentifier == userIdentifier);
+
+			if(user is null) return;
+
+			var recipeIds = await _dbContext.Recipes
+		  .Where(r => r.UserId == user.Id)
+		  .Select(r => r.Id)
+		  .ToListAsync();
+
+			var dishtypes = _dbContext.RecipesDishTypes.Where(rdt => recipeIds.Contains(rdt.RecipeId));
+
+			var recipes = _dbContext.Recipes.Where(r => recipeIds.Contains(r.Id));
+
+			_dbContext.Recipes.RemoveRange(recipes);
+
+			_dbContext.Users.Remove(user);
+		}
+	}
 }

--- a/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/UserRepository.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DataAccess/Repositories/UserRepository.cs
@@ -57,8 +57,6 @@ namespace MyRecipeBook.Infrastructure.DataAccess.Repositories
 		  .Select(r => r.Id)
 		  .ToListAsync();
 
-			var dishtypes = _dbContext.RecipesDishTypes.Where(rdt => recipeIds.Contains(rdt.RecipeId));
-
 			var recipes = _dbContext.Recipes.Where(r => recipeIds.Contains(r.Id));
 
 			_dbContext.Recipes.RemoveRange(recipes);

--- a/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Storage.Blobs;
+﻿using Azure.Messaging.ServiceBus;
+using Azure.Storage.Blobs;
 using FluentMigrator.Runner;
 using GenerativeAI;
 using Microsoft.EntityFrameworkCore;
@@ -15,6 +16,7 @@ using MyRecipeBook.Domain.Security.Cryptography;
 using MyRecipeBook.Domain.Security.Tokens;
 using MyRecipeBook.Domain.Services.GeminiApi;
 using MyRecipeBook.Domain.Services.LoggedUser;
+using MyRecipeBook.Domain.Services.ServiceBus;
 using MyRecipeBook.Domain.Services.Storage;
 using MyRecipeBook.Infrastructure.DataAccess;
 using MyRecipeBook.Infrastructure.DataAccess.Repositories;
@@ -24,6 +26,7 @@ using MyRecipeBook.Infrastructure.Security.Tokens.Access.Generator;
 using MyRecipeBook.Infrastructure.Security.Tokens.Access.Validator;
 using MyRecipeBook.Infrastructure.Services.GeminiApi;
 using MyRecipeBook.Infrastructure.Services.LoggedUser;
+using MyRecipeBook.Infrastructure.Services.ServiceBus;
 using MyRecipeBook.Infrastructure.Services.Storage;
 using System.Reflection;
 
@@ -31,6 +34,8 @@ namespace MyRecipeBook.Infrastructure
 {
 	public static class DepedencyInjectionExtension
 	{
+
+		private const string QUEUE_NAME = "user";
 		public static void AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
 		{
 			AddRepositories(services);
@@ -39,6 +44,7 @@ namespace MyRecipeBook.Infrastructure
 			AddPasswordEncripter(services, configuration);
 			AddGeminiAI(services, configuration);
 			AddAzureStorage(services, configuration);
+			AddQueue(services, configuration);
 
 			if(configuration.IsUnitTestEnviroment()) return;
 
@@ -64,6 +70,7 @@ namespace MyRecipeBook.Infrastructure
 			services.AddScoped<IUserWriteOnlyRepository, UserRepository>();
 			services.AddScoped<IUserReadOnlyRepository, UserRepository>();
 			services.AddScoped<IUserUpdateOnlyRepository, UserRepository>();
+			services.AddScoped<IUserDeleteOnlyRepository, UserRepository>();
 
 			services.AddScoped<ICookingTimeReadOnlyRepository, CookingTimeRepository>();
 			services.AddScoped<IDifficultyReadOnlyRepository, DifficultyRepository>();
@@ -75,6 +82,27 @@ namespace MyRecipeBook.Infrastructure
 
 			services.AddScoped<IRecipesDishTypeWriteOnlyRepository, RecipesDishTypeRepository>();
 
+		}
+
+		private static void AddQueue(IServiceCollection services, IConfiguration configuration)
+		{
+			var connectionString = configuration.GetValue<string>("Settings:ServiceBus:DeleteUserAccount");
+
+			var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
+			{
+				TransportType = ServiceBusTransportType.AmqpWebSockets
+			});
+
+			var deleteQueue = new DeleteUserQueue(client.CreateSender(QUEUE_NAME));
+
+			var deleteUserProcessor = new DeleteUserProcessor(client.CreateProcessor(QUEUE_NAME, new ServiceBusProcessorOptions
+			{
+				MaxConcurrentCalls = 1
+			}));
+
+			services.AddSingleton(deleteUserProcessor.GetProcessor());
+
+			services.AddScoped<IDeleteUserQueue>(o => deleteQueue);
 		}
 
 		private static void AddFluentMigrator(IServiceCollection services, IConfiguration configuration)

--- a/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/DepedencyInjectionExtension.cs
@@ -88,6 +88,8 @@ namespace MyRecipeBook.Infrastructure
 		{
 			var connectionString = configuration.GetValue<string>("Settings:ServiceBus:DeleteUserAccount");
 
+			if(string.IsNullOrWhiteSpace(connectionString)) return;
+
 			var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
 			{
 				TransportType = ServiceBusTransportType.AmqpWebSockets

--- a/src/backend/MyRecipeBook.Infrastructure/MyRecipeBook.Infrastructure.csproj
+++ b/src/backend/MyRecipeBook.Infrastructure/MyRecipeBook.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="FluentMigrator" Version="7.1.0" />

--- a/src/backend/MyRecipeBook.Infrastructure/Services/ServiceBus/DeleteUserProcessor.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Services/ServiceBus/DeleteUserProcessor.cs
@@ -1,0 +1,16 @@
+﻿using Azure.Messaging.ServiceBus;
+
+namespace MyRecipeBook.Infrastructure.Services.ServiceBus
+{
+	public class DeleteUserProcessor
+	{
+		private readonly ServiceBusProcessor _processor;
+
+		public DeleteUserProcessor(ServiceBusProcessor processor)
+		{
+			_processor = processor;
+		}
+
+		public ServiceBusProcessor GetProcessor() => _processor;
+	}
+}

--- a/src/backend/MyRecipeBook.Infrastructure/Services/ServiceBus/DeleteUserQueue.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Services/ServiceBus/DeleteUserQueue.cs
@@ -1,0 +1,21 @@
+﻿using Azure.Messaging.ServiceBus;
+using MyRecipeBook.Domain.Entities;
+using MyRecipeBook.Domain.Services.ServiceBus;
+
+namespace MyRecipeBook.Infrastructure.Services.ServiceBus
+{
+	public class DeleteUserQueue:IDeleteUserQueue
+	{
+		private readonly ServiceBusSender _serviceBusSender;
+
+		public DeleteUserQueue(ServiceBusSender serviceBusSender)
+		{
+			_serviceBusSender = serviceBusSender;
+		}
+
+		public async Task SendMessage(User user)
+		{
+			await _serviceBusSender.SendMessageAsync(new ServiceBusMessage(user.UserIdentifier.ToString()));
+		}
+	}
+}

--- a/src/backend/MyRecipeBook.Infrastructure/Services/Storage/AzureStorageService.cs
+++ b/src/backend/MyRecipeBook.Infrastructure/Services/Storage/AzureStorageService.cs
@@ -26,6 +26,12 @@ namespace MyRecipeBook.Infrastructure.Services.Storage
 			await containerClient.DeleteBlobIfExistsAsync(imageIdentifier);
 		}
 
+		public async Task DeleteContainer(Guid userIdentifier)
+		{
+			var container = _blobServiceClient.GetBlobContainerClient(blobContainerName: userIdentifier.ToString());
+			await container.DeleteIfExistsAsync();
+		}
+
 		public async Task<String> GetFileUrl(User user, String imageIdentifier)
 		{
 			var containerName = user.UserIdentifier.ToString();

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
@@ -74,6 +74,7 @@ namespace MyRecipeBook.Application
 			services.AddScoped<IDeleteRecipeUseCase, DeleteRecipeUseCase>();
 			services.AddScoped<IGeneratedRecipeUseCase, GeneratedRecipeUseCase>();
 			services.AddScoped<IAddUpdateImageCoverUseCase, AddUpdateImageCoverUseCase>();
+			services.AddScoped<RecipeRegisterServices, RecipeRegisterServices>();
 
 			services.AddScoped<IGetDashboardUseCase, GetDashboardUseCase>();
 

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/DepedencyInjectionExtension.cs
@@ -11,6 +11,8 @@ using MyRecipeBook.Application.UseCases.Recipe.Image;
 using MyRecipeBook.Application.UseCases.Recipe.Register;
 using MyRecipeBook.Application.UseCases.Recipe.Update;
 using MyRecipeBook.Application.UseCases.User.ChangePassword;
+using MyRecipeBook.Application.UseCases.User.Delete;
+using MyRecipeBook.Application.UseCases.User.Delete.Request;
 using MyRecipeBook.Application.UseCases.User.Profile;
 using MyRecipeBook.Application.UseCases.User.Register;
 using MyRecipeBook.Application.UseCases.User.Update;
@@ -62,6 +64,8 @@ namespace MyRecipeBook.Application
 			services.AddScoped<IGetUserProfileUseCase, GetUserProfileUseCase>();
 			services.AddScoped<IUpdateUserUseCase, UpdateUserUseCase>();
 			services.AddScoped<IChangePasswordUseCase, ChangePasswordUseCase>();
+			services.AddScoped<IDeleteUserUseCase, DeleteUserUseCase>();
+			services.AddScoped<IDeleteUserAccountUseCase, DeleteUserAccountUseCase>();
 
 			services.AddScoped<IRegisterRecipeUseCase, RegisterRecipeUseCase>();
 			services.AddScoped<IFilterRecipeUseCase, FilterRecipeUseCase>();

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RecipeRegisterServices.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RecipeRegisterServices.cs
@@ -1,0 +1,23 @@
+﻿using AutoMapper;
+using MyRecipeBook.Domain.Repositories;
+using MyRecipeBook.Domain.Services.LoggedUser;
+using MyRecipeBook.Domain.Services.Storage;
+
+namespace MyRecipeBook.Application.UseCases.Recipe.Register
+{
+	public class RecipeRegisterServices
+	{
+		public ILoggedUser _loggedUser { get; }
+		public IUnitOfWork _unitOfWork { get; }
+		public IMapper _mapper { get; }
+		public IBlobStorageService _blobStorageService { get; }
+
+		public RecipeRegisterServices(ILoggedUser loggedUser, IUnitOfWork unitOfWork, IMapper mapper, IBlobStorageService blobStorageService)
+		{
+			_loggedUser = loggedUser;
+			_unitOfWork = unitOfWork;
+			_mapper = mapper;
+			_blobStorageService = blobStorageService;
+		}
+	}
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/Recipe/Register/RegisterRecipeUseCase.cs
@@ -24,48 +24,41 @@ namespace MyRecipeBook.Application.UseCases.Recipe.Register
 		private readonly IDifficultyReadOnlyRepository _repositoryDifficultyTime;
 		private readonly IDishTypeReadOnlyRepository _repositoryDishType;
 
-		private readonly ILoggedUser _loggedUser;
-		private readonly IUnitOfWork _unitOfWork;
-		private readonly IMapper _mapper;
-		private readonly IBlobStorageService _blobStorageService;
+		private readonly RecipeRegisterServices _recipeRegisterServices;
+
+
 
 		public RegisterRecipeUseCase(
 			 IRecipeWriteOnlyRepository repository,
 			 ICookingTimeReadOnlyRepository repositoryCookingTime,
 			 IDifficultyReadOnlyRepository repositoryDifficultyTime,
 			 IDishTypeReadOnlyRepository repositoryDishType,
-			 ILoggedUser loggedUser,
-			 IUnitOfWork unitOfWork,
-			 IMapper mapper,
-			 IBlobStorageService blobStorageService
+			 RecipeRegisterServices recipeRegisterServices
 			 )
 		{
 			_repository = repository;
 			_repositoryCookingTime = repositoryCookingTime;
 			_repositoryDifficultyTime = repositoryDifficultyTime;
 			_repositoryDishType = repositoryDishType;
-			_loggedUser = loggedUser;
-			_unitOfWork = unitOfWork;
-			_mapper = mapper;
-			_blobStorageService = blobStorageService;
+			_recipeRegisterServices = recipeRegisterServices;
 		}
 
 		public async Task<ResponseRegisteredRecipeJson> Execute(RequestRegisterRecipeFormData request)
 		{
 			await ValidateAsync(request);
 
-			var loggedUser = await _loggedUser.User();
+			var loggedUser = await _recipeRegisterServices._loggedUser.User();
 
-			var recipe = _mapper.Map<Domain.Entities.Recipe>(request);
+			var recipe = _recipeRegisterServices._mapper.Map<Domain.Entities.Recipe>(request);
 			recipe.UserId = loggedUser.Id;
 
 			var instructions = request.Instructions.OrderBy(i => i.Step).ToList();
 			for(var i = 0;i < instructions.Count;i++)
 				instructions[i].Step = i + 1;
 
-			recipe.Instructions = _mapper.Map<IList<Domain.Entities.Instruction>>(instructions);
+			recipe.Instructions = _recipeRegisterServices._mapper.Map<IList<Domain.Entities.Instruction>>(instructions);
 
-			recipe.RecipeDishTypes = _mapper.Map<IList<Domain.Entities.RecipeDishType>>(request.DishTypes);
+			recipe.RecipeDishTypes = _recipeRegisterServices._mapper.Map<IList<Domain.Entities.RecipeDishType>>(request.DishTypes);
 
 			if(request.Image is not null)
 			{
@@ -78,14 +71,14 @@ namespace MyRecipeBook.Application.UseCases.Recipe.Register
 
 				recipe.ImageIdentifier = imageIdentifier;
 
-				await _blobStorageService.Upload(loggedUser, fileStream, recipe.ImageIdentifier);
+				await _recipeRegisterServices._blobStorageService.Upload(loggedUser, fileStream, recipe.ImageIdentifier);
 			}
 
 			await _repository.Add(recipe);
 
-			await _unitOfWork.Commit();
+			await _recipeRegisterServices._unitOfWork.Commit();
 
-			return _mapper.Map<ResponseRegisteredRecipeJson>(recipe);
+			return _recipeRegisterServices._mapper.Map<ResponseRegisteredRecipeJson>(recipe);
 		}
 
 		private async Task ValidateAsync(RequestRecipeJson request)

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/DeleteUserAccountUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/DeleteUserAccountUseCase.cs
@@ -1,0 +1,31 @@
+﻿
+using MyRecipeBook.Domain.Repositories;
+using MyRecipeBook.Domain.Repositories.User;
+using MyRecipeBook.Domain.Services.Storage;
+
+namespace MyRecipeBook.Application.UseCases.User.Delete
+{
+	public class DeleteUserAccountUseCase:IDeleteUserAccountUseCase
+	{
+		private readonly IUserDeleteOnlyRepository _repository;
+		private readonly IUnitOfWork _unitOfWork;
+		private readonly IBlobStorageService _blobStorageService;
+
+		public DeleteUserAccountUseCase(IUserDeleteOnlyRepository repository, IUnitOfWork unitOfWork, IBlobStorageService blobStorageService)
+		{
+			_repository = repository;
+			_unitOfWork = unitOfWork;
+			_blobStorageService = blobStorageService;
+		}
+
+		public async Task Execute(Guid userIdentifier)
+		{
+			await _blobStorageService.DeleteContainer(userIdentifier);
+
+			await _repository.DeleteAccount(userIdentifier);
+
+			await _unitOfWork.Commit ();
+		}
+
+	}
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/IDeleteUserAccountUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/IDeleteUserAccountUseCase.cs
@@ -1,0 +1,7 @@
+﻿namespace MyRecipeBook.Application.UseCases.User.Delete
+{
+	public interface IDeleteUserAccountUseCase
+	{
+		Task Execute(Guid userIdentifier);
+	}
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/Request/DeleteUserUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/Request/DeleteUserUseCase.cs
@@ -1,0 +1,38 @@
+﻿using MyRecipeBook.Domain.Repositories;
+using MyRecipeBook.Domain.Repositories.User;
+using MyRecipeBook.Domain.Services.LoggedUser;
+using MyRecipeBook.Domain.Services.ServiceBus;
+
+namespace MyRecipeBook.Application.UseCases.User.Delete.Request
+{
+	public class DeleteUserUseCase:IDeleteUserUseCase
+	{
+		private readonly IDeleteUserQueue _queue;
+		private readonly IUserUpdateOnlyRepository _userUpdateOnlyRepository;
+		private readonly ILoggedUser _loggedUser;
+		private readonly IUnitOfWork _unitOfWork;
+
+		public DeleteUserUseCase(IDeleteUserQueue queue, IUserUpdateOnlyRepository userUpdateOnlyRepository, ILoggedUser loggedUser, IUnitOfWork unitOfWork)
+		{
+			_queue = queue;
+			_userUpdateOnlyRepository = userUpdateOnlyRepository;
+			_loggedUser = loggedUser;
+			_unitOfWork = unitOfWork;
+		}
+
+		public async Task Execute()
+		{
+			var loggedUser = await _loggedUser.User();
+
+			var user = await _userUpdateOnlyRepository.GetById(loggedUser.Id);
+
+			user.Active = false;
+			
+			_userUpdateOnlyRepository.Update(user);
+
+			await _unitOfWork.Commit();
+
+			await _queue.SendMessage(loggedUser);
+		}
+	}
+}

--- a/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/Request/IDeleteUserUseCase.cs
+++ b/src/backend/MyRecipebook.Application/MyRecipeBook.Application/UseCases/User/Delete/Request/IDeleteUserUseCase.cs
@@ -1,0 +1,7 @@
+﻿namespace MyRecipeBook.Application.UseCases.User.Delete.Request
+{
+	public interface IDeleteUserUseCase
+	{
+		public Task Execute();
+	}
+}

--- a/tests/UseCases.Test/Recipe/Delete/Delete/DeleteUserAccountUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Delete/Delete/DeleteUserAccountUseCaseTest.cs
@@ -1,0 +1,35 @@
+﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.Repositories;
+using MyRecipeBook.Application.UseCases.User.Delete;
+using Shouldly;
+
+namespace UseCases.Test.Recipe.Delete.Delete
+{
+	public class DeleteUserAccountUseCaseTest
+	{
+		[Fact]
+		public async Task Success()
+		{
+			(var user, _) = UserBuilder.Build();
+
+			var useCase = CreateUseCase();
+
+			var act = async () => await useCase.Execute(user.UserIdentifier);
+
+			await act.ShouldNotThrowAsync();
+		}
+
+		private static DeleteUserAccountUseCase CreateUseCase()
+		{
+			var deleteOnlyRepository = new UserDeleteOnlyRepositoryBuilder().Build();
+			var unitOfWork = UnitOfWorkBuilder.Build();
+			var blobStorage = new CommonTestUtilities.BlobStorage.BlobStorageServiceBuilder().Build();
+
+			return new DeleteUserAccountUseCase(
+				repository: deleteOnlyRepository,
+				unitOfWork: unitOfWork,
+				blobStorageService: blobStorage
+				);
+		}
+	}
+}

--- a/tests/UseCases.Test/Recipe/Delete/Request/DeleteRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Delete/Request/DeleteRecipeUseCaseTest.cs
@@ -5,7 +5,7 @@ using MyRecipeBook.Application.UseCases.Recipe.Delete;
 using MyRecipeBook.Exceptions.ExceptionsBase;
 using Shouldly;
 
-namespace UseCases.Test.Recipe.Delete
+namespace UseCases.Test.Recipe.Delete.Request
 {
 	public class DeleteRecipeUseCaseTest
 	{

--- a/tests/UseCases.Test/Recipe/Image/AddUpdateImageCoverUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Image/AddUpdateImageCoverUseCaseTest.cs
@@ -71,7 +71,7 @@ namespace UseCases.Test.Recipe.Image
 
 		}
 
-		private static AddUpdateImageCoverUseCase CreateUseCase(MyRecipeBook.Domain.Entities.User user, MyRecipeBook.Domain.Entities.Recipe recipe = null)
+		private static AddUpdateImageCoverUseCase CreateUseCase(MyRecipeBook.Domain.Entities.User user, MyRecipeBook.Domain.Entities.Recipe? recipe = null)
 		{
 			var loggedUser = LoggedUserBuilder.Build(user);
 			var recipeUpdateOnlyRepository = new RecipeUpdateOnlyRepositoryBuilder().GetById(user, recipe).Build();

--- a/tests/UseCases.Test/Recipe/Register/RegisterRecipeUseCaseTest.cs
+++ b/tests/UseCases.Test/Recipe/Register/RegisterRecipeUseCaseTest.cs
@@ -108,7 +108,13 @@ namespace UseCases.Test.Recipe.Register
 			var repositoryDishType = new DishTypeReadOnlyRepositoryBuilder();
 			repositoryDishType.ExistsAnyDishType();
 
-			return new RegisterRecipeUseCase(repository, repositoryCookingTime.Build(), repositoryDifficulty.Build(), repositoryDishType.Build(), loggedUser, unitOfWork, mapper, blobStorage);
+			var repositoryCategory = new RecipeRegisterServices(
+				loggedUser: loggedUser, 
+				blobStorageService: blobStorage, 
+				unitOfWork: unitOfWork, 
+				mapper: mapper);
+
+			return new RegisterRecipeUseCase(repository, repositoryCookingTime.Build(), repositoryDifficulty.Build(), repositoryDishType.Build(), repositoryCategory);
 		}
 
 	}

--- a/tests/UseCases.Test/User/Delete/DeleteUserUseCaseTest.cs
+++ b/tests/UseCases.Test/User/Delete/DeleteUserUseCaseTest.cs
@@ -1,0 +1,41 @@
+﻿using CommonTestUtilities.Entities;
+using CommonTestUtilities.LoggedUser;
+using CommonTestUtilities.Repositories;
+using CommonTestUtilities.ServiceBus;
+using MyRecipeBook.Application.UseCases.User.Delete.Request;
+using Shouldly;
+
+namespace UseCases.Test.User.Delete
+{
+	public class DeleteUserUseCaseTest
+	{
+		[Fact]
+		public async Task Success()
+		{
+			(var user, _) = UserBuilder.Build();
+
+			var useCase = CreateUseCase(user);
+
+			var act = async () => await useCase.Execute();
+
+			await act.ShouldNotThrowAsync();
+
+			user.Active.ShouldBeFalse();
+		}
+
+		private static DeleteUserUseCase CreateUseCase(MyRecipeBook.Domain.Entities.User user)
+		{
+			var loggedUser = LoggedUserBuilder.Build(user);
+			var unitOfWork = UnitOfWorkBuilder.Build();
+			var userUpdateOnlyRepository = new UserUpdateOnlyRepositoryBuilder().GetById(user).Build();
+			var queue = DeleteUserQueueBuilder.Build();
+
+			return new DeleteUserUseCase(
+				queue: queue,
+				userUpdateOnlyRepository: userUpdateOnlyRepository,
+				loggedUser: loggedUser,
+				unitOfWork: unitOfWork
+				);
+		}
+	}
+}


### PR DESCRIPTION
- Added `DeleteUserService`, a background service listening to Service Bus for user deletion.
- Created `DeleteUserUseCase` for marking users inactive and sending deletion messages.
- Implemented `DeleteUserAccountUseCase` for final deletion of user data and storage containers.
- Extended `UserRepository` with `IUserDeleteOnlyRepository` to remove user records and recipes.
- Registered necessary dependencies and processors in DI container.
- Updated `UserController` with a new `DELETE` endpoint to initiate deletion flow.